### PR TITLE
Make netlify deploy previews work well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - python/install-deps
       - python/save-cache
       - run:
-          command: mkdir docs && scripts/create-api.py > docs/api.json
+          command: scripts/create-api.py > docs/api.json
           name: Build
       - persist_to_workspace:
           root: docs

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,7 @@
+<html>
+  <head><title>Glean Annotations</title></head>
+  <body><h1>Glean Annotations</h1>
+  <p>This is a deployed copy of the glean annotations.
+    You can see the JSON representation of these annotations at <a href="api.json">api.json</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
Add an index to ease navigation inside the deploy preview.

Deploy previews will let us more easily test some changes, like adding new annotation types.