### PR TITLE
Add Firefox-iOS `tabs.open` notes

### DIFF
--- a/annotations/firefox_ios/metrics/tabs.open/README.md
+++ b/annotations/firefox_ios/metrics/tabs.open/README.md
@@ -1,0 +1,4 @@
+This is best used as an indication of how often a client opens new a new tab and not how many tabs that are open.
+This is due to the fact that this metric only counts the number of tabs _opened_ by the user during the current 
+metrics ping time window, it doesn't account for any tabs that may have already been open prior to the beginning 
+of the metrics ping window.


### PR DESCRIPTION
Adding an annotation for `tabs.open` for Firefox-iOS