### PR TITLE
Point users at parsed_start_time instead of start_time

### DIFF
--- a/annotations/glean-core/metrics/start_time/README.md
+++ b/annotations/glean-core/metrics/start_time/README.md
@@ -1,0 +1,2 @@
+This ends up being a string in the data and is not easily parsed into a `DATE` or `TIMESTAMP`, thus there is a 
+pre-parsed version that is much easier to use `ping_info.parsed_start_time` when writing queries.


### PR DESCRIPTION
start_time recommendation to use `parsed_start_time` when  writing queries.