### PR TITLE
Point users at parsed_end_time instead of end_time

### DIFF
--- a/annotations/glean-core/metrics/end_time/README.md
+++ b/annotations/glean-core/metrics/end_time/README.md
@@ -1,0 +1,2 @@
+This ends up being a string in the data and is not easily parsed into a `DATE` or `TIMESTAMP`, thus there is a 
+pre-parsed version that is much easier to use `ping_info.parsed_end_time` when writing queries.


### PR DESCRIPTION
This adds a note pointing query writers trying to use `ping_info.end_time` at the parsed version `ping_info.parsed_end_time`