### PR TITLE
Replace usage of `labels` with `tags`

### DIFF
--- a/annotations/fenix/metadata.yaml
+++ b/annotations/fenix/metadata.yaml
@@ -1,4 +1,4 @@
-labels:
+tags:
   Accounts: Corresponds to the [Feature:Accounts](https://github.com/mozilla-mobile/fenix/issues?q=label%3AFeature%3AAccounts)
     label on GitHub.
   AndroidIntegration: Corresponds to the [Feature:AndroidIntegration](https://github.com/mozilla-mobile/fenix/issues?q=label%3AFeature%3AAndroidIntegration)

--- a/annotations/fenix/metrics/addons.enabled_addons/README.md
+++ b/annotations/fenix/metrics/addons.enabled_addons/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- WebExtensions
+tags:
+  - WebExtensions
 ---
+
 This is a stub commentary for the `addons.enabled_addons` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/addons.has_enabled_addons/README.md
+++ b/annotations/fenix/metrics/addons.has_enabled_addons/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- WebExtensions
+tags:
+  - WebExtensions
 ---
+
 This is a stub commentary for the `addons.has_enabled_addons` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/addons.has_installed_addons/README.md
+++ b/annotations/fenix/metrics/addons.has_installed_addons/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- WebExtensions
+tags:
+  - WebExtensions
 ---
+
 This is a stub commentary for the `addons.has_installed_addons` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/addons.installed_addons/README.md
+++ b/annotations/fenix/metrics/addons.installed_addons/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- WebExtensions
+tags:
+  - WebExtensions
 ---
+
 This is a stub commentary for the `addons.installed_addons` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/addons.open_addon_in_toolbar_menu/README.md
+++ b/annotations/fenix/metrics/addons.open_addon_in_toolbar_menu/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- WebExtensions
+tags:
+  - WebExtensions
 ---
+
 This is a stub commentary for the `addons.open_addon_in_toolbar_menu` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/addons.open_addon_setting/README.md
+++ b/annotations/fenix/metrics/addons.open_addon_setting/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- WebExtensions
+tags:
+  - WebExtensions
 ---
+
 This is a stub commentary for the `addons.open_addon_setting` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/addons.open_addons_in_settings/README.md
+++ b/annotations/fenix/metrics/addons.open_addons_in_settings/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- WebExtensions
+tags:
+  - WebExtensions
 ---
+
 This is a stub commentary for the `addons.open_addons_in_settings` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/app_theme.dark_theme_selected/README.md
+++ b/annotations/fenix/metrics/app_theme.dark_theme_selected/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Themes
+tags:
+  - Themes
 ---
+
 This is a stub commentary for the `app_theme.dark_theme_selected` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/autoplay.setting_changed/README.md
+++ b/annotations/fenix/metrics/autoplay.setting_changed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- SitePermissions
+tags:
+  - SitePermissions
 ---
+
 This is a stub commentary for the `autoplay.setting_changed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/autoplay.visited_setting/README.md
+++ b/annotations/fenix/metrics/autoplay.visited_setting/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- SitePermissions
+tags:
+  - SitePermissions
 ---
+
 This is a stub commentary for the `autoplay.visited_setting` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.copied/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.copied/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.copied` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.edited/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.edited/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.edited` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.folder_add/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.folder_add/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.folder_add` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.moved/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.moved/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.moved` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.multi_removed/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.multi_removed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.multi_removed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.open_in_new_tab/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.open_in_new_tab/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.open_in_new_tab` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.open_in_new_tabs/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.open_in_new_tabs/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.open_in_new_tabs` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.open_in_private_tab/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.open_in_private_tab/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.open_in_private_tab` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.open_in_private_tabs/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.open_in_private_tabs/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.open_in_private_tabs` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.removed/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.removed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.removed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.shared/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.shared/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `bookmarks_management.shared` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/browser.search.ad_clicks/README.md
+++ b/annotations/fenix/metrics/browser.search.ad_clicks/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Search
+tags:
+  - Search
 ---
+
 This is a stub commentary for the `browser.search.ad_clicks` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/browser.search.in_content/README.md
+++ b/annotations/fenix/metrics/browser.search.in_content/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Search
+tags:
+  - Search
 ---
+
 Around the mid January 2021 for Nightly/Beta and end January 2021 for Release, telemetry was implemented for Google topsite tile.
 
 This implementation leads to the increase in both the `tagged_sap` and `tagged_follow_on` and drop in `organic` in the `mobile_search_clients_daily` (hence all tables based on it). You can see https://sql.telemetry.mozilla.org/queries/79738/source#198048 the increase in `tagged_rate`.

--- a/annotations/fenix/metrics/browser.search.with_ads/README.md
+++ b/annotations/fenix/metrics/browser.search.with_ads/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Search
+tags:
+  - Search
 ---
+
 This is a stub commentary for the `browser.search.with_ads` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.add_tab_button/README.md
+++ b/annotations/fenix/metrics/collections.add_tab_button/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.add_tab_button` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.all_tabs_restored/README.md
+++ b/annotations/fenix/metrics/collections.all_tabs_restored/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.all_tabs_restored` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.long_press/README.md
+++ b/annotations/fenix/metrics/collections.long_press/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.long_press` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.removed/README.md
+++ b/annotations/fenix/metrics/collections.removed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.removed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.rename_button/README.md
+++ b/annotations/fenix/metrics/collections.rename_button/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.rename_button` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.renamed/README.md
+++ b/annotations/fenix/metrics/collections.renamed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.renamed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.save_button/README.md
+++ b/annotations/fenix/metrics/collections.save_button/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.save_button` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.saved/README.md
+++ b/annotations/fenix/metrics/collections.saved/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.saved` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.shared/README.md
+++ b/annotations/fenix/metrics/collections.shared/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.shared` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.tab_removed/README.md
+++ b/annotations/fenix/metrics/collections.tab_removed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.tab_removed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.tab_restored/README.md
+++ b/annotations/fenix/metrics/collections.tab_restored/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.tab_restored` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.tab_select_opened/README.md
+++ b/annotations/fenix/metrics/collections.tab_select_opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.tab_select_opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/collections.tabs_added/README.md
+++ b/annotations/fenix/metrics/collections.tabs_added/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Collections
+tags:
+  - Collections
 ---
+
 This is a stub commentary for the `collections.tabs_added` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/context_menu.item_tapped/README.md
+++ b/annotations/fenix/metrics/context_menu.item_tapped/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Sharing
+tags:
+  - Sharing
 ---
+
 This is a stub commentary for the `context_menu.item_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_hint.tracking_protection.dismiss/README.md
+++ b/annotations/fenix/metrics/contextual_hint.tracking_protection.dismiss/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TrackingProtection
+tags:
+  - TrackingProtection
 ---
+
 This is a stub commentary for the `contextual_hint.tracking_protection.dismiss` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_hint.tracking_protection.display/README.md
+++ b/annotations/fenix/metrics/contextual_hint.tracking_protection.display/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TrackingProtection
+tags:
+  - TrackingProtection
 ---
+
 This is a stub commentary for the `contextual_hint.tracking_protection.display` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_hint.tracking_protection.inside_tap/README.md
+++ b/annotations/fenix/metrics/contextual_hint.tracking_protection.inside_tap/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TrackingProtection
+tags:
+  - TrackingProtection
 ---
+
 This is a stub commentary for the `contextual_hint.tracking_protection.inside_tap` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_hint.tracking_protection.outside_tap/README.md
+++ b/annotations/fenix/metrics/contextual_hint.tracking_protection.outside_tap/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TrackingProtection
+tags:
+  - TrackingProtection
 ---
+
 This is a stub commentary for the `contextual_hint.tracking_protection.outside_tap` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_menu.copy_tapped/README.md
+++ b/annotations/fenix/metrics/contextual_menu.copy_tapped/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- ContextMenu
-- TextSelection
+tags:
+  - ContextMenu
+  - TextSelection
 ---
+
 This is a stub commentary for the `contextual_menu.copy_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_menu.long_press_tapped/README.md
+++ b/annotations/fenix/metrics/contextual_menu.long_press_tapped/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- ContextMenu
-- TextSelection
+tags:
+  - ContextMenu
+  - TextSelection
 ---
+
 This is a stub commentary for the `contextual_menu.long_press_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_menu.search_tapped/README.md
+++ b/annotations/fenix/metrics/contextual_menu.search_tapped/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- ContextMenu
-- TextSelection
+tags:
+  - ContextMenu
+  - TextSelection
 ---
+
 This is a stub commentary for the `contextual_menu.search_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_menu.select_all_tapped/README.md
+++ b/annotations/fenix/metrics/contextual_menu.select_all_tapped/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- ContextMenu
-- TextSelection
+tags:
+  - ContextMenu
+  - TextSelection
 ---
+
 This is a stub commentary for the `contextual_menu.select_all_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_menu.share_tapped/README.md
+++ b/annotations/fenix/metrics/contextual_menu.share_tapped/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- ContextMenu
-- TextSelection
+tags:
+  - ContextMenu
+  - TextSelection
 ---
+
 This is a stub commentary for the `contextual_menu.share_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/crash_reporter.closed/README.md
+++ b/annotations/fenix/metrics/crash_reporter.closed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- CrashReporting
+tags:
+  - CrashReporting
 ---
+
 This is a stub commentary for the `crash_reporter.closed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/crash_reporter.opened/README.md
+++ b/annotations/fenix/metrics/crash_reporter.opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- CrashReporting
+tags:
+  - CrashReporting
 ---
+
 This is a stub commentary for the `crash_reporter.opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/custom_tab.action_button/README.md
+++ b/annotations/fenix/metrics/custom_tab.action_button/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- CustomTabs
+tags:
+  - CustomTabs
 ---
+
 This is a stub commentary for the `custom_tab.action_button` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/custom_tab.closed/README.md
+++ b/annotations/fenix/metrics/custom_tab.closed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- CustomTabs
+tags:
+  - CustomTabs
 ---
+
 This is a stub commentary for the `custom_tab.closed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/custom_tab.menu/README.md
+++ b/annotations/fenix/metrics/custom_tab.menu/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- CustomTabs
+tags:
+  - CustomTabs
 ---
+
 This is a stub commentary for the `custom_tab.menu` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/downloads_management.downloads_screen_opened/README.md
+++ b/annotations/fenix/metrics/downloads_management.downloads_screen_opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Download
+tags:
+  - Download
 ---
+
 This is a stub commentary for the `downloads_management.downloads_screen_opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/downloads_management.item_deleted/README.md
+++ b/annotations/fenix/metrics/downloads_management.item_deleted/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Download
+tags:
+  - Download
 ---
+
 This is a stub commentary for the `downloads_management.item_deleted` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/downloads_management.item_opened/README.md
+++ b/annotations/fenix/metrics/downloads_management.item_opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Download
+tags:
+  - Download
 ---
+
 This is a stub commentary for the `downloads_management.item_opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/downloads_misc.download_added/README.md
+++ b/annotations/fenix/metrics/downloads_misc.download_added/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Download
+tags:
+  - Download
 ---
+
 This is a stub commentary for the `downloads_misc.download_added` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/error_page.visited_error/README.md
+++ b/annotations/fenix/metrics/error_page.visited_error/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- ErrorMessages
+tags:
+  - ErrorMessages
 ---
+
 This is a stub commentary for the `error_page.visited_error` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/events.copy_url_tapped/README.md
+++ b/annotations/fenix/metrics/events.copy_url_tapped/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- ContextMenu
+tags:
+  - ContextMenu
 ---
+
 This is a stub commentary for the `events.copy_url_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/events.normal_and_private_uri_count/README.md
+++ b/annotations/fenix/metrics/events.normal_and_private_uri_count/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `events.normal_and_private_uri_count` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/events.opened_link/README.md
+++ b/annotations/fenix/metrics/events.opened_link/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `events.opened_link` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/events.preference_toggled/README.md
+++ b/annotations/fenix/metrics/events.preference_toggled/README.md
@@ -1,11 +1,12 @@
 ---
-labels:
-- Bookmarks
-- History
-- Logins
-- PrivateBrowsing
-- Search
+tags:
+  - Bookmarks
+  - History
+  - Logins
+  - PrivateBrowsing
+  - Search
 ---
+
 This is a stub commentary for the `events.preference_toggled` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/events.recently_closed_tabs_opened/README.md
+++ b/annotations/fenix/metrics/events.recently_closed_tabs_opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `events.recently_closed_tabs_opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/events.synced_tab_opened/README.md
+++ b/annotations/fenix/metrics/events.synced_tab_opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- SyncTabs
+tags:
+  - SyncTabs
 ---
+
 This is a stub commentary for the `events.synced_tab_opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/events.tab_counter_menu_action/README.md
+++ b/annotations/fenix/metrics/events.tab_counter_menu_action/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `events.tab_counter_menu_action` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/history.opened/README.md
+++ b/annotations/fenix/metrics/history.opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- History
+tags:
+  - History
 ---
+
 This is a stub commentary for the `history.opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/history.removed/README.md
+++ b/annotations/fenix/metrics/history.removed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- History
+tags:
+  - History
 ---
+
 This is a stub commentary for the `history.removed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/history.removed_all/README.md
+++ b/annotations/fenix/metrics/history.removed_all/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- History
+tags:
+  - History
 ---
+
 This is a stub commentary for the `history.removed_all` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/history.shared/README.md
+++ b/annotations/fenix/metrics/history.shared/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- History
+tags:
+  - History
 ---
+
 This is a stub commentary for the `history.shared` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/home_menu.settings_item_clicked/README.md
+++ b/annotations/fenix/metrics/home_menu.settings_item_clicked/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Settings
+tags:
+  - Settings
 ---
+
 This is a stub commentary for the `{}` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/home_screen.home_screen_displayed/README.md
+++ b/annotations/fenix/metrics/home_screen.home_screen_displayed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Settings
+tags:
+  - Settings
 ---
+
 This is a stub commentary for the `{}` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/login_dialog.cancelled/README.md
+++ b/annotations/fenix/metrics/login_dialog.cancelled/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `login_dialog.cancelled` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/login_dialog.displayed/README.md
+++ b/annotations/fenix/metrics/login_dialog.displayed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `login_dialog.displayed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/login_dialog.never_save/README.md
+++ b/annotations/fenix/metrics/login_dialog.never_save/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `login_dialog.never_save` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/login_dialog.saved/README.md
+++ b/annotations/fenix/metrics/login_dialog.saved/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `login_dialog.saved` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/logins.copy_login/README.md
+++ b/annotations/fenix/metrics/logins.copy_login/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `logins.copy_login` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/logins.delete_saved_login/README.md
+++ b/annotations/fenix/metrics/logins.delete_saved_login/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `logins.delete_saved_login` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/logins.open_individual_login/README.md
+++ b/annotations/fenix/metrics/logins.open_individual_login/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `logins.open_individual_login` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/logins.open_login_editor/README.md
+++ b/annotations/fenix/metrics/logins.open_login_editor/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `logins.open_login_editor` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/logins.open_logins/README.md
+++ b/annotations/fenix/metrics/logins.open_logins/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `logins.open_logins` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/logins.save_edited_login/README.md
+++ b/annotations/fenix/metrics/logins.save_edited_login/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `logins.save_edited_login` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/logins.save_logins_setting_changed/README.md
+++ b/annotations/fenix/metrics/logins.save_logins_setting_changed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `logins.save_logins_setting_changed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/logins.view_password_login/README.md
+++ b/annotations/fenix/metrics/logins.view_password_login/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `logins.view_password_login` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/media_notification.pause/README.md
+++ b/annotations/fenix/metrics/media_notification.pause/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Media
+tags:
+  - Media
 ---
+
 This is a stub commentary for the `media_notification.pause` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/media_notification.play/README.md
+++ b/annotations/fenix/metrics/media_notification.play/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Media
+tags:
+  - Media
 ---
+
 This is a stub commentary for the `media_notification.play` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/media_state.fullscreen/README.md
+++ b/annotations/fenix/metrics/media_state.fullscreen/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Media
+tags:
+  - Media
 ---
+
 This is a stub commentary for the `media_state.fullscreen` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/media_state.pause/README.md
+++ b/annotations/fenix/metrics/media_state.pause/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Media
+tags:
+  - Media
 ---
+
 This is a stub commentary for the `media_state.pause` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/media_state.picture_in_picture/README.md
+++ b/annotations/fenix/metrics/media_state.picture_in_picture/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Media
+tags:
+  - Media
 ---
+
 This is a stub commentary for the `media_state.picture_in_picture` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/media_state.play/README.md
+++ b/annotations/fenix/metrics/media_state.play/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Media
+tags:
+  - Media
 ---
+
 This is a stub commentary for the `media_state.play` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/media_state.stop/README.md
+++ b/annotations/fenix/metrics/media_state.stop/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Media
+tags:
+  - Media
 ---
+
 This is a stub commentary for the `media_state.stop` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.close_tab_setting/README.md
+++ b/annotations/fenix/metrics/metrics.close_tab_setting/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `metrics.close_tab_setting` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.desktop_bookmarks_count/README.md
+++ b/annotations/fenix/metrics/metrics.desktop_bookmarks_count/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `metrics.desktop_bookmarks_count` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.distribution_id/README.md
+++ b/annotations/fenix/metrics/metrics.distribution_id/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- China
+tags:
+  - China
 ---
+
 This is a stub commentary for the `metrics.distribution_id` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.has_desktop_bookmarks/README.md
+++ b/annotations/fenix/metrics/metrics.has_desktop_bookmarks/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `metrics.has_desktop_bookmarks` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.has_mobile_bookmarks/README.md
+++ b/annotations/fenix/metrics/metrics.has_mobile_bookmarks/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `metrics.has_mobile_bookmarks` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.has_open_tabs/README.md
+++ b/annotations/fenix/metrics/metrics.has_open_tabs/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `metrics.has_open_tabs` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.has_recent_pwas/README.md
+++ b/annotations/fenix/metrics/metrics.has_recent_pwas/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PWA
+tags:
+  - PWA
 ---
+
 This is a stub commentary for the `metrics.has_recent_pwas` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.has_top_sites/README.md
+++ b/annotations/fenix/metrics/metrics.has_top_sites/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `metrics.has_top_sites` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.mobile_bookmarks_count/README.md
+++ b/annotations/fenix/metrics/metrics.mobile_bookmarks_count/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Bookmarks
+tags:
+  - Bookmarks
 ---
+
 This is a stub commentary for the `metrics.mobile_bookmarks_count` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.recently_used_pwa_count/README.md
+++ b/annotations/fenix/metrics/metrics.recently_used_pwa_count/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PWA
+tags:
+  - PWA
 ---
+
 This is a stub commentary for the `metrics.recently_used_pwa_count` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.search_count/README.md
+++ b/annotations/fenix/metrics/metrics.search_count/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Search
+tags:
+  - Search
 ---
+
 Possible values for search_count 'type':
 
 - `action`: User typed the full query and searched through the toolbar (hit enter)

--- a/annotations/fenix/metrics/metrics.search_widget_installed/README.md
+++ b/annotations/fenix/metrics/metrics.search_widget_installed/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- Discovery
-- Search
+tags:
+  - Discovery
+  - Search
 ---
+
 This is a stub commentary for the `metrics.search_widget_installed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.tab_view_setting/README.md
+++ b/annotations/fenix/metrics/metrics.tab_view_setting/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 An example query showing the values sent for this metric in the last 28 days can be found in https://sql.telemetry.mozilla.org/queries/79505/source.
 As of this writing (Apr 21, 2021), this metric will often be sent as null due to an implementation issue:
 see [mozilla-mobile/fenix#19147](https://github.com/mozilla-mobile/fenix/issues/19147) for details.

--- a/annotations/fenix/metrics/metrics.tabs_open_count/README.md
+++ b/annotations/fenix/metrics/metrics.tabs_open_count/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `metrics.tabs_open_count` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.toolbar_position/README.md
+++ b/annotations/fenix/metrics/metrics.toolbar_position/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Toolbar
+tags:
+  - Toolbar
 ---
+
 This is a stub commentary for the `metrics.toolbar_position` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.top_sites_count/README.md
+++ b/annotations/fenix/metrics/metrics.top_sites_count/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `metrics.top_sites_count` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.bookmark_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.bookmark_suggestions/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.awesomebar.bookmark_suggestions` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.clipboard_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.clipboard_suggestions/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.awesomebar.clipboard_suggestions` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.history_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.history_suggestions/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.awesomebar.history_suggestions` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.search_engine_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.search_engine_suggestions/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.awesomebar.search_engine_suggestions` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.session_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.session_suggestions/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.awesomebar.session_suggestions` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.shortcuts_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.shortcuts_suggestions/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.awesomebar.shortcuts_suggestions` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.synced_tabs_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.synced_tabs_suggestions/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.awesomebar.synced_tabs_suggestions` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.app_on_create_to_glean_init/README.md
+++ b/annotations/fenix/metrics/perf.startup.app_on_create_to_glean_init/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.app_on_create_to_glean_init` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.app_on_create_to_megazord_init/README.md
+++ b/annotations/fenix/metrics/perf.startup.app_on_create_to_megazord_init/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.app_on_create_to_megazord_init` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.app_on_create_to_setup_in_main/README.md
+++ b/annotations/fenix/metrics/perf.startup.app_on_create_to_setup_in_main/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.app_on_create_to_setup_in_main` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.application_on_create/README.md
+++ b/annotations/fenix/metrics/perf.startup.application_on_create/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.application_on_create` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.base_bfragment_on_create_view/README.md
+++ b/annotations/fenix/metrics/perf.startup.base_bfragment_on_create_view/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.base_bfragment_on_create_view` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.base_bfragment_on_view_created/README.md
+++ b/annotations/fenix/metrics/perf.startup.base_bfragment_on_view_created/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.base_bfragment_on_view_created` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.cold_main_app_to_first_frame/README.md
+++ b/annotations/fenix/metrics/perf.startup.cold_main_app_to_first_frame/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.cold_main_app_to_first_frame` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.cold_unknwn_app_to_first_frame/README.md
+++ b/annotations/fenix/metrics/perf.startup.cold_unknwn_app_to_first_frame/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.cold_unknwn_app_to_first_frame` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.cold_view_app_to_first_frame/README.md
+++ b/annotations/fenix/metrics/perf.startup.cold_view_app_to_first_frame/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.cold_view_app_to_first_frame` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.home_activity_on_create/README.md
+++ b/annotations/fenix/metrics/perf.startup.home_activity_on_create/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.home_activity_on_create` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.home_activity_on_start/README.md
+++ b/annotations/fenix/metrics/perf.startup.home_activity_on_start/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.home_activity_on_start` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.home_fragment_on_create_view/README.md
+++ b/annotations/fenix/metrics/perf.startup.home_fragment_on_create_view/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.home_fragment_on_create_view` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.home_fragment_on_view_created/README.md
+++ b/annotations/fenix/metrics/perf.startup.home_fragment_on_view_created/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.home_fragment_on_view_created` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.startup_type/README.md
+++ b/annotations/fenix/metrics/perf.startup.startup_type/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Performance
+tags:
+  - Performance
 ---
+
 This is a stub commentary for the `perf.startup.startup_type` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/pocket.pocket_top_site_clicked/README.md
+++ b/annotations/fenix/metrics/pocket.pocket_top_site_clicked/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `pocket.pocket_top_site_clicked` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/pocket.pocket_top_site_removed/README.md
+++ b/annotations/fenix/metrics/pocket.pocket_top_site_removed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `pocket.pocket_top_site_removed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.open_links_in_a_private_tab/README.md
+++ b/annotations/fenix/metrics/preferences.open_links_in_a_private_tab/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - PrivateBrowsing
 ---
 

--- a/annotations/fenix/metrics/preferences.search_bookmarks/README.md
+++ b/annotations/fenix/metrics/preferences.search_bookmarks/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - Bookmarks
 ---
 

--- a/annotations/fenix/metrics/preferences.search_browsing_history/README.md
+++ b/annotations/fenix/metrics/preferences.search_browsing_history/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - History
 ---
 

--- a/annotations/fenix/metrics/preferences.search_suggestions_private/README.md
+++ b/annotations/fenix/metrics/preferences.search_suggestions_private/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - Search
 ---
 

--- a/annotations/fenix/metrics/preferences.show_search_shortcuts/README.md
+++ b/annotations/fenix/metrics/preferences.show_search_shortcuts/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - Search
 ---
 

--- a/annotations/fenix/metrics/preferences.show_search_suggestions/README.md
+++ b/annotations/fenix/metrics/preferences.show_search_suggestions/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - Search
 ---
 

--- a/annotations/fenix/metrics/preferences.show_voice_search/README.md
+++ b/annotations/fenix/metrics/preferences.show_voice_search/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - Search
   - Voice
 ---

--- a/annotations/fenix/metrics/preferences.sync/README.md
+++ b/annotations/fenix/metrics/preferences.sync/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - Sync
 ---
 

--- a/annotations/fenix/metrics/preferences.telemetry/README.md
+++ b/annotations/fenix/metrics/preferences.telemetry/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - Telemetry
 ---
 

--- a/annotations/fenix/metrics/preferences.theme/README.md
+++ b/annotations/fenix/metrics/preferences.theme/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - Themes
 ---
 

--- a/annotations/fenix/metrics/preferences.toolbar_position/README.md
+++ b/annotations/fenix/metrics/preferences.toolbar_position/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - Toolbar
 ---
 

--- a/annotations/fenix/metrics/preferences.tracking_protection/README.md
+++ b/annotations/fenix/metrics/preferences.tracking_protection/README.md
@@ -1,5 +1,5 @@
 ---
-labels:
+tags:
   - TrackingProtection
 ---
 

--- a/annotations/fenix/metrics/private_browsing_mode.garbage_icon/README.md
+++ b/annotations/fenix/metrics/private_browsing_mode.garbage_icon/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_mode.garbage_icon` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_mode.notification_delete/README.md
+++ b/annotations/fenix/metrics/private_browsing_mode.notification_delete/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_mode.notification_delete` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_mode.notification_open/README.md
+++ b/annotations/fenix/metrics/private_browsing_mode.notification_open/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_mode.notification_open` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_mode.notification_tapped/README.md
+++ b/annotations/fenix/metrics/private_browsing_mode.notification_tapped/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_mode.notification_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_mode.snackbar_undo/README.md
+++ b/annotations/fenix/metrics/private_browsing_mode.snackbar_undo/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_mode.snackbar_undo` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.cfr_add_shortcut/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.cfr_add_shortcut/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_shortcut.cfr_add_shortcut` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.cfr_cancel/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.cfr_cancel/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_shortcut.cfr_cancel` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.create_shortcut/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.create_shortcut/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_shortcut.create_shortcut` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.pinned_shortcut_priv/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.pinned_shortcut_priv/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_shortcut.pinned_shortcut_priv` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.static_shortcut_priv/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.static_shortcut_priv/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_shortcut.static_shortcut_priv` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.static_shortcut_tab/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.static_shortcut_tab/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PrivateBrowsing
+tags:
+  - PrivateBrowsing
 ---
+
 This is a stub commentary for the `private_browsing_shortcut.static_shortcut_tab` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/progressive_web_app.background/README.md
+++ b/annotations/fenix/metrics/progressive_web_app.background/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PWA
+tags:
+  - PWA
 ---
+
 This is a stub commentary for the `progressive_web_app.background` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/progressive_web_app.foreground/README.md
+++ b/annotations/fenix/metrics/progressive_web_app.foreground/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PWA
+tags:
+  - PWA
 ---
+
 This is a stub commentary for the `progressive_web_app.foreground` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/progressive_web_app.homescreen_tap/README.md
+++ b/annotations/fenix/metrics/progressive_web_app.homescreen_tap/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PWA
+tags:
+  - PWA
 ---
+
 This is a stub commentary for the `progressive_web_app.homescreen_tap` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/progressive_web_app.install_tap/README.md
+++ b/annotations/fenix/metrics/progressive_web_app.install_tap/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- PWA
+tags:
+  - PWA
 ---
+
 This is a stub commentary for the `progressive_web_app.install_tap` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/qr_scanner.navigation_allowed/README.md
+++ b/annotations/fenix/metrics/qr_scanner.navigation_allowed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- QRCode
+tags:
+  - QRCode
 ---
+
 This is a stub commentary for the `qr_scanner.navigation_allowed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/qr_scanner.navigation_denied/README.md
+++ b/annotations/fenix/metrics/qr_scanner.navigation_denied/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- QRCode
+tags:
+  - QRCode
 ---
+
 This is a stub commentary for the `qr_scanner.navigation_denied` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/qr_scanner.opened/README.md
+++ b/annotations/fenix/metrics/qr_scanner.opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- QRCode
+tags:
+  - QRCode
 ---
+
 This is a stub commentary for the `qr_scanner.opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/qr_scanner.prompt_displayed/README.md
+++ b/annotations/fenix/metrics/qr_scanner.prompt_displayed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- QRCode
+tags:
+  - QRCode
 ---
+
 This is a stub commentary for the `qr_scanner.prompt_displayed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/reader_mode.appearance/README.md
+++ b/annotations/fenix/metrics/reader_mode.appearance/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- ReaderMode
+tags:
+  - ReaderMode
 ---
+
 This is a stub commentary for the `reader_mode.appearance` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/reader_mode.available/README.md
+++ b/annotations/fenix/metrics/reader_mode.available/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- ReaderMode
+tags:
+  - ReaderMode
 ---
+
 This is a stub commentary for the `reader_mode.available` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/reader_mode.closed/README.md
+++ b/annotations/fenix/metrics/reader_mode.closed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- ReaderMode
+tags:
+  - ReaderMode
 ---
+
 This is a stub commentary for the `reader_mode.closed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/reader_mode.opened/README.md
+++ b/annotations/fenix/metrics/reader_mode.opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- ReaderMode
+tags:
+  - ReaderMode
 ---
+
 This is a stub commentary for the `reader_mode.opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/search.default_engine.code/README.md
+++ b/annotations/fenix/metrics/search.default_engine.code/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- SearchProvider
+tags:
+  - SearchProvider
 ---
+
 This is a stub commentary for the `search.default_engine.code` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/search.default_engine.name/README.md
+++ b/annotations/fenix/metrics/search.default_engine.name/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- SearchProvider
+tags:
+  - SearchProvider
 ---
+
 This is a stub commentary for the `search.default_engine.name` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/search.default_engine.submission_url/README.md
+++ b/annotations/fenix/metrics/search.default_engine.submission_url/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- SearchProvider
+tags:
+  - SearchProvider
 ---
+
 This is a stub commentary for the `search.default_engine.submission_url` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/search_shortcuts.selected/README.md
+++ b/annotations/fenix/metrics/search_shortcuts.selected/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Shortcuts
+tags:
+  - Shortcuts
 ---
+
 This is a stub commentary for the `search_shortcuts.selected` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/search_suggestions.enable_in_private/README.md
+++ b/annotations/fenix/metrics/search_suggestions.enable_in_private/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Search
+tags:
+  - Search
 ---
+
 This is a stub commentary for the `search_suggestions.enable_in_private` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/search_widget_cfr.add_widget_pressed/README.md
+++ b/annotations/fenix/metrics/search_widget_cfr.add_widget_pressed/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- Discovery
-- Search
+tags:
+  - Discovery
+  - Search
 ---
+
 This is a stub commentary for the `search_widget_cfr.add_widget_pressed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/search_widget_cfr.canceled/README.md
+++ b/annotations/fenix/metrics/search_widget_cfr.canceled/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- Discovery
-- Search
+tags:
+  - Discovery
+  - Search
 ---
+
 This is a stub commentary for the `search_widget_cfr.canceled` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/search_widget_cfr.displayed/README.md
+++ b/annotations/fenix/metrics/search_widget_cfr.displayed/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- Discovery
-- Search
+tags:
+  - Discovery
+  - Search
 ---
+
 This is a stub commentary for the `search_widget_cfr.displayed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/search_widget_cfr.not_now_pressed/README.md
+++ b/annotations/fenix/metrics/search_widget_cfr.not_now_pressed/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- Discovery
-- Search
+tags:
+  - Discovery
+  - Search
 ---
+
 This is a stub commentary for the `search_widget_cfr.not_now_pressed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/sync_account.send_tab/README.md
+++ b/annotations/fenix/metrics/sync_account.send_tab/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- SendTab
+tags:
+  - SendTab
 ---
+
 This is a stub commentary for the `sync_account.send_tab` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/sync_account.sign_in_to_send_tab/README.md
+++ b/annotations/fenix/metrics/sync_account.sign_in_to_send_tab/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- SendTab
+tags:
+  - SendTab
 ---
+
 This is a stub commentary for the `sync_account.sign_in_to_send_tab` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.auto_login/README.md
+++ b/annotations/fenix/metrics/sync_auth.auto_login/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Accounts
+tags:
+  - Accounts
 ---
+
 This is a stub commentary for the `sync_auth.auto_login` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.other_external/README.md
+++ b/annotations/fenix/metrics/sync_auth.other_external/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Accounts
+tags:
+  - Accounts
 ---
+
 This is a stub commentary for the `sync_auth.other_external` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.paired/README.md
+++ b/annotations/fenix/metrics/sync_auth.paired/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Accounts
+tags:
+  - Accounts
 ---
+
 This is a stub commentary for the `sync_auth.paired` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.recovered/README.md
+++ b/annotations/fenix/metrics/sync_auth.recovered/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Accounts
+tags:
+  - Accounts
 ---
+
 This is a stub commentary for the `sync_auth.recovered` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.sign_up/README.md
+++ b/annotations/fenix/metrics/sync_auth.sign_up/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Accounts
+tags:
+  - Accounts
 ---
+
 This is a stub commentary for the `sync_auth.sign_up` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.use_email/README.md
+++ b/annotations/fenix/metrics/sync_auth.use_email/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Sync
+tags:
+  - Sync
 ---
+
 This is a stub commentary for the `sync_auth.use_email` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.use_email_problem/README.md
+++ b/annotations/fenix/metrics/sync_auth.use_email_problem/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Sync
+tags:
+  - Sync
 ---
+
 This is a stub commentary for the `sync_auth.use_email_problem` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tab.media_pause/README.md
+++ b/annotations/fenix/metrics/tab.media_pause/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Media
+tags:
+  - Media
 ---
+
 This is a stub commentary for the `tab.media_pause` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tab.media_play/README.md
+++ b/annotations/fenix/metrics/tab.media_play/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Media
+tags:
+  - Media
 ---
+
 This is a stub commentary for the `tab.media_play` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs.setting_opened/README.md
+++ b/annotations/fenix/metrics/tabs.setting_opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs.setting_opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.close_all_tabs/README.md
+++ b/annotations/fenix/metrics/tabs_tray.close_all_tabs/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.close_all_tabs` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.closed/README.md
+++ b/annotations/fenix/metrics/tabs_tray.closed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.closed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.closed_existing_tab/README.md
+++ b/annotations/fenix/metrics/tabs_tray.closed_existing_tab/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.closed_existing_tab` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.menu_opened/README.md
+++ b/annotations/fenix/metrics/tabs_tray.menu_opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.menu_opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.new_private_tab_tapped/README.md
+++ b/annotations/fenix/metrics/tabs_tray.new_private_tab_tapped/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.new_private_tab_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.new_tab_tapped/README.md
+++ b/annotations/fenix/metrics/tabs_tray.new_tab_tapped/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.new_tab_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.normal_mode_tapped/README.md
+++ b/annotations/fenix/metrics/tabs_tray.normal_mode_tapped/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.normal_mode_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.opened/README.md
+++ b/annotations/fenix/metrics/tabs_tray.opened/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.opened` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.opened_existing_tab/README.md
+++ b/annotations/fenix/metrics/tabs_tray.opened_existing_tab/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.opened_existing_tab` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.private_mode_tapped/README.md
+++ b/annotations/fenix/metrics/tabs_tray.private_mode_tapped/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.private_mode_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.save_to_collection/README.md
+++ b/annotations/fenix/metrics/tabs_tray.save_to_collection/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.save_to_collection` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.share_all_tabs/README.md
+++ b/annotations/fenix/metrics/tabs_tray.share_all_tabs/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Tabs
+tags:
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.share_all_tabs` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.synced_mode_tapped/README.md
+++ b/annotations/fenix/metrics/tabs_tray.synced_mode_tapped/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- SyncTabs
-- Tabs
+tags:
+  - SyncTabs
+  - Tabs
 ---
+
 This is a stub commentary for the `tabs_tray.synced_mode_tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tip.closed/README.md
+++ b/annotations/fenix/metrics/tip.closed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Discovery
+tags:
+  - Discovery
 ---
+
 This is a stub commentary for the `tip.closed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tip.displayed/README.md
+++ b/annotations/fenix/metrics/tip.displayed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Discovery
+tags:
+  - Discovery
 ---
+
 This is a stub commentary for the `tip.displayed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tip.pressed/README.md
+++ b/annotations/fenix/metrics/tip.pressed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Discovery
+tags:
+  - Discovery
 ---
+
 This is a stub commentary for the `tip.pressed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/toolbar_settings.changed_position/README.md
+++ b/annotations/fenix/metrics/toolbar_settings.changed_position/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Toolbar
+tags:
+  - Toolbar
 ---
+
 This is a stub commentary for the `toolbar_settings.changed_position` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.long_press/README.md
+++ b/annotations/fenix/metrics/top_sites.long_press/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `top_sites.long_press` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_default/README.md
+++ b/annotations/fenix/metrics/top_sites.open_default/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `top_sites.open_default` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_frecency/README.md
+++ b/annotations/fenix/metrics/top_sites.open_frecency/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `top_sites.open_frecency` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_in_new_tab/README.md
+++ b/annotations/fenix/metrics/top_sites.open_in_new_tab/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `top_sites.open_in_new_tab` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_in_private_tab/README.md
+++ b/annotations/fenix/metrics/top_sites.open_in_private_tab/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `top_sites.open_in_private_tab` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_pinned/README.md
+++ b/annotations/fenix/metrics/top_sites.open_pinned/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `top_sites.open_pinned` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.remove/README.md
+++ b/annotations/fenix/metrics/top_sites.remove/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `top_sites.remove` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.swipe_carousel/README.md
+++ b/annotations/fenix/metrics/top_sites.swipe_carousel/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TopSites
+tags:
+  - TopSites
 ---
+
 This is a stub commentary for the `top_sites.swipe_carousel` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.etp_setting_changed/README.md
+++ b/annotations/fenix/metrics/tracking_protection.etp_setting_changed/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TrackingProtection
+tags:
+  - TrackingProtection
 ---
+
 This is a stub commentary for the `tracking_protection.etp_setting_changed` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.etp_settings/README.md
+++ b/annotations/fenix/metrics/tracking_protection.etp_settings/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TrackingProtection
+tags:
+  - TrackingProtection
 ---
+
 This is a stub commentary for the `tracking_protection.etp_settings` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.etp_shield/README.md
+++ b/annotations/fenix/metrics/tracking_protection.etp_shield/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TrackingProtection
+tags:
+  - TrackingProtection
 ---
+
 This is a stub commentary for the `tracking_protection.etp_shield` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.etp_tracker_list/README.md
+++ b/annotations/fenix/metrics/tracking_protection.etp_tracker_list/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TrackingProtection
+tags:
+  - TrackingProtection
 ---
+
 This is a stub commentary for the `tracking_protection.etp_tracker_list` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.exception_added/README.md
+++ b/annotations/fenix/metrics/tracking_protection.exception_added/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TrackingProtection
+tags:
+  - TrackingProtection
 ---
+
 This is a stub commentary for the `tracking_protection.exception_added` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.panel_settings/README.md
+++ b/annotations/fenix/metrics/tracking_protection.panel_settings/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- TrackingProtection
+tags:
+  - TrackingProtection
 ---
+
 This is a stub commentary for the `tracking_protection.panel_settings` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/user_specified_search_engines.custom_engine_added/README.md
+++ b/annotations/fenix/metrics/user_specified_search_engines.custom_engine_added/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- SearchProvider
+tags:
+  - SearchProvider
 ---
+
 This is a stub commentary for the `user_specified_search_engines.custom_engine_added` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/user_specified_search_engines.custom_engine_deleted/README.md
+++ b/annotations/fenix/metrics/user_specified_search_engines.custom_engine_deleted/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- SearchProvider
+tags:
+  - SearchProvider
 ---
+
 This is a stub commentary for the `user_specified_search_engines.custom_engine_deleted` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/user_specified_search_engines.search_with_custom_engine/README.md
+++ b/annotations/fenix/metrics/user_specified_search_engines.search_with_custom_engine/README.md
@@ -1,7 +1,8 @@
 ---
-labels:
-- Logins
+tags:
+  - Logins
 ---
+
 This is a stub commentary for the `user_specified_search_engines.search_with_custom_engine` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/annotations/fenix/metrics/voice_search.tapped/README.md
+++ b/annotations/fenix/metrics/voice_search.tapped/README.md
@@ -1,8 +1,9 @@
 ---
-labels:
-- Search
-- Voice
+tags:
+  - Search
+  - Voice
 ---
+
 This is a stub commentary for the `voice_search.tapped` metric: please feel free to edit (read the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 if you haven't done this before)

--- a/scripts/create-api.py
+++ b/scripts/create-api.py
@@ -36,24 +36,23 @@ def linkify(text):
     return text
 
 
-def read_annotation(filename, valid_labels):
+def read_annotation(filename, valid_tags):
     annotation_md = frontmatter.load(filename)
 
     annotation = {"content": linkify(annotation_md.content)}
-    for key in ["component", "features", "warning"]:
+    for key in ["component", "tags", "warning"]:
         if annotation_md.get(key):
             annotation[key] = annotation_md[key]
 
-    labels = annotation_md.get("labels")
-    if labels:
-        invalid_labels = [label for label in labels if label not in valid_labels]
-        if invalid_labels:
+    tags = annotation_md.get("tags")
+    if tags:
+        invalid_tags = [tag for tag in tags if tag not in valid_tags]
+        if invalid_tags:
             sys.stderr.write(
-                f"Invalid labels found in {annotation_filename}: {invalid_labels}; "
+                f"Invalid tags found in {annotation_filename}: {invalid_tags}; "
                 f" if these should be accepted values, update annotations/{app}/metadata.yaml"
             )
             sys.exit(1)
-        annotation["labels"] = labels
 
     return annotation
 
@@ -68,11 +67,11 @@ for app in apps:
         pass
 
     app_dir = os.path.join(ANNOTATIONS_DIR, app)
-    valid_labels = []
+    valid_tags = []
     try:
         metadata = yaml.load(open(os.path.join(app_dir, "metadata.yaml")))
         data[app].update(metadata)
-        valid_labels = metadata.get("labels", []).keys()
+        valid_tags = metadata.get("tags", []).keys()
     except:
         pass
     for annotation_type in ("metrics", "pings"):
@@ -84,7 +83,7 @@ for app in apps:
         annotation_ids = os.listdir(annotation_dir)
         for annotation_id in annotation_ids:
             data[app][annotation_type][annotation_id] = read_annotation(
-                os.path.join(annotation_dir, annotation_id, "README.md"), valid_labels
+                os.path.join(annotation_dir, annotation_id, "README.md"), valid_tags
             )
 
 print(json.dumps(data))

--- a/scripts/scrape-fenix
+++ b/scripts/scrape-fenix
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-Toolkit for scraping GitHub feature labels from Fenix data reviews and using
+Toolkit for scraping GitHub feature tags from Fenix data reviews and using
 them to create a preliminary set of metric annotations.
 
 Usage:
@@ -91,8 +91,8 @@ def update_annotation(metric, features, overwrite_existing):
             annotation_md = frontmatter.load(annotation_filename)
             content = annotation_md.content
             metadata = annotation_md.metadata
-            if not overwrite_existing and metadata.get("labels"):
-                # if the frontmatter already has labels defined, let's not update
+            if not overwrite_existing and metadata.get("tags"):
+                # if the frontmatter already has tags defined, let's not update
                 # unless specifically asked to
                 return
         else:
@@ -100,7 +100,7 @@ def update_annotation(metric, features, overwrite_existing):
             content = STUB_COMMENTARY.format(metric)
             metadata = {}
 
-        metadata.update({"labels": sorted(features)})
+        metadata.update({"tags": sorted(features)})
         # metric file already exists, just update the frontmatter and re-save
         annotation_dir.mkdir(exist_ok=True)
         open(annotation_filename, "w").write(
@@ -114,11 +114,11 @@ def cli():
 
 
 @cli.command()
-def update_label_definitions():
+def update_tag_definitions():
     """
     Scrapes GitHub labels for Fenix
 
-    Find all labels marked "Feature:" and put them into metadata.yaml
+    Find all labels marked "Feature:" and put them into metadata.yaml as tags
     """
     labels = requests.get(
         "https://api.github.com/repos/mozilla-mobile/fenix/labels?per_page=100"
@@ -140,14 +140,14 @@ def update_label_definitions():
                 abbreviated_label
             ] = f"{label_description}Corresponds to the [{label['name']}]({url}) label on GitHub."
 
-    open(FENIX_METADATA, "w").write(yaml.dump({"labels": feature_map}))
+    open(FENIX_METADATA, "w").write(yaml.dump({"tags": feature_map}))
 
 
 @cli.command()
 @click.argument("output")
 def scrape_metric_feature_map(output):
     """
-    Gets a feature map of metrics to feature labels via scraping
+    Gets a feature map of metrics to feature tags via scraping
 
     This command is intended mainly for debugging. Generally one would just run
     update-metric-labels.


### PR DESCRIPTION
Labels are often used when defining metrics themselves (e.g. the labels
in labelled counters), so it's better to use a term that doesn't have
the same namespace collision.
