### PR TITLE
Add explicit warnings in metadata for some fenix metrics

### DIFF
--- a/annotations/fenix/metrics/preferences.open_links_in_a_private_tab/README.md
+++ b/annotations/fenix/metrics/preferences.open_links_in_a_private_tab/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - PrivateBrowsing
 ---

--- a/annotations/fenix/metrics/preferences.open_links_in_app/README.md
+++ b/annotations/fenix/metrics/preferences.open_links_in_app/README.md
@@ -1,2 +1,6 @@
+---
+warning: This metric should not be used. See the commentary for details.
+---
+
 This metric has been replaced by `preferences.open_links_in_app_enabled` and should not be used.
 It will often be sent as null due to an implementation issue: see [mozilla-mobile/fenix#19147](https://github.com/mozilla-mobile/fenix/issues/19147) for details.

--- a/annotations/fenix/metrics/preferences.remote_debugging/README.md
+++ b/annotations/fenix/metrics/preferences.remote_debugging/README.md
@@ -1,2 +1,6 @@
+---
+warning: This metric should not be used. See the commentary for details.
+---
+
 This metric has been replaced by `preferences.remote_debugging_enabled` and should not be used.
 It will often be sent as null due to an implementation issue: see [mozilla-mobile/fenix#19147](https://github.com/mozilla-mobile/fenix/issues/19147) for details.

--- a/annotations/fenix/metrics/preferences.search_bookmarks/README.md
+++ b/annotations/fenix/metrics/preferences.search_bookmarks/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - Bookmarks
 ---

--- a/annotations/fenix/metrics/preferences.search_browsing_history/README.md
+++ b/annotations/fenix/metrics/preferences.search_browsing_history/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - History
 ---

--- a/annotations/fenix/metrics/preferences.search_suggestions_private/README.md
+++ b/annotations/fenix/metrics/preferences.search_suggestions_private/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - Search
 ---

--- a/annotations/fenix/metrics/preferences.show_clipboard_suggestions/README.md
+++ b/annotations/fenix/metrics/preferences.show_clipboard_suggestions/README.md
@@ -1,2 +1,6 @@
+---
+warning: This metric should not be used. See the commentary for details.
+---
+
 This metric has been replaced by `preferences.clipboard_suggestions_enabled` and should not be used.
 It will often be sent as null due to an implementation issue: see [mozilla-mobile/fenix#19147](https://github.com/mozilla-mobile/fenix/issues/19147) for details.

--- a/annotations/fenix/metrics/preferences.show_search_shortcuts/README.md
+++ b/annotations/fenix/metrics/preferences.show_search_shortcuts/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - Search
 ---

--- a/annotations/fenix/metrics/preferences.show_search_suggestions/README.md
+++ b/annotations/fenix/metrics/preferences.show_search_suggestions/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - Search
 ---

--- a/annotations/fenix/metrics/preferences.show_voice_search/README.md
+++ b/annotations/fenix/metrics/preferences.show_voice_search/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - Search
   - Voice

--- a/annotations/fenix/metrics/preferences.sync/README.md
+++ b/annotations/fenix/metrics/preferences.sync/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - Sync
 ---

--- a/annotations/fenix/metrics/preferences.telemetry/README.md
+++ b/annotations/fenix/metrics/preferences.telemetry/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - Telemetry
 ---

--- a/annotations/fenix/metrics/preferences.theme/README.md
+++ b/annotations/fenix/metrics/preferences.theme/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - Themes
 ---

--- a/annotations/fenix/metrics/preferences.toolbar_position/README.md
+++ b/annotations/fenix/metrics/preferences.toolbar_position/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - Toolbar
 ---

--- a/annotations/fenix/metrics/preferences.tracking_protection/README.md
+++ b/annotations/fenix/metrics/preferences.tracking_protection/README.md
@@ -1,4 +1,5 @@
 ---
+warning: This metric should not be used. See the commentary for details.
 tags:
   - TrackingProtection
 ---


### PR DESCRIPTION
We can surface this warning more prominently in the Glean Dictionary
than we do currently. See: https://mozilla.github.io/glean-annotations/contributing/metadata/#warnings
