### PR TITLE
Fix contributing URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,2 @@
-Please see the [contributing documentation](https://mozilla.github.io/contributing.html) for information
+Please see the [contributing documentation](https://mozilla.github.io/glean-annotations/contributing/) for information
 on how to contribute to this repository.


### PR DESCRIPTION
The current URL was giving a 404. Updating the URL to point here instead: https://mozilla.github.io/glean-annotations/contributing/ (I'm assuming this is the correct URL?)