### PR TITLE
Allow "content" for an annotation to be blank and remove stub commentary

### DIFF
--- a/annotations/fenix/metrics/activation.activation_id/README.md
+++ b/annotations/fenix/metrics/activation.activation_id/README.md
@@ -2,7 +2,3 @@
 tags:
   - Privacy&Security
 ---
-
-This is a stub commentary for the `activation.activation_id` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/activation.identifier/README.md
+++ b/annotations/fenix/metrics/activation.identifier/README.md
@@ -2,7 +2,3 @@
 tags:
   - Privacy&Security
 ---
-
-This is a stub commentary for the `activation.identifier` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/addons.enabled_addons/README.md
+++ b/annotations/fenix/metrics/addons.enabled_addons/README.md
@@ -2,7 +2,3 @@
 tags:
   - WebExtensions
 ---
-
-This is a stub commentary for the `addons.enabled_addons` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/addons.has_enabled_addons/README.md
+++ b/annotations/fenix/metrics/addons.has_enabled_addons/README.md
@@ -2,7 +2,3 @@
 tags:
   - WebExtensions
 ---
-
-This is a stub commentary for the `addons.has_enabled_addons` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/addons.has_installed_addons/README.md
+++ b/annotations/fenix/metrics/addons.has_installed_addons/README.md
@@ -2,7 +2,3 @@
 tags:
   - WebExtensions
 ---
-
-This is a stub commentary for the `addons.has_installed_addons` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/addons.installed_addons/README.md
+++ b/annotations/fenix/metrics/addons.installed_addons/README.md
@@ -2,7 +2,3 @@
 tags:
   - WebExtensions
 ---
-
-This is a stub commentary for the `addons.installed_addons` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/addons.open_addon_in_toolbar_menu/README.md
+++ b/annotations/fenix/metrics/addons.open_addon_in_toolbar_menu/README.md
@@ -2,7 +2,3 @@
 tags:
   - WebExtensions
 ---
-
-This is a stub commentary for the `addons.open_addon_in_toolbar_menu` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/addons.open_addon_setting/README.md
+++ b/annotations/fenix/metrics/addons.open_addon_setting/README.md
@@ -2,7 +2,3 @@
 tags:
   - WebExtensions
 ---
-
-This is a stub commentary for the `addons.open_addon_setting` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/addons.open_addons_in_settings/README.md
+++ b/annotations/fenix/metrics/addons.open_addons_in_settings/README.md
@@ -2,7 +2,3 @@
 tags:
   - WebExtensions
 ---
-
-This is a stub commentary for the `addons.open_addons_in_settings` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/app_theme.dark_theme_selected/README.md
+++ b/annotations/fenix/metrics/app_theme.dark_theme_selected/README.md
@@ -2,7 +2,3 @@
 tags:
   - Themes
 ---
-
-This is a stub commentary for the `app_theme.dark_theme_selected` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/autoplay.setting_changed/README.md
+++ b/annotations/fenix/metrics/autoplay.setting_changed/README.md
@@ -2,7 +2,3 @@
 tags:
   - SitePermissions
 ---
-
-This is a stub commentary for the `autoplay.setting_changed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/autoplay.visited_setting/README.md
+++ b/annotations/fenix/metrics/autoplay.visited_setting/README.md
@@ -2,7 +2,3 @@
 tags:
   - SitePermissions
 ---
-
-This is a stub commentary for the `autoplay.visited_setting` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/awesomebar.bookmark_suggestion_clicked/README.md
+++ b/annotations/fenix/metrics/awesomebar.bookmark_suggestion_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `awesomebar.bookmark_suggestion_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/awesomebar.clipboard_suggestion_clicked/README.md
+++ b/annotations/fenix/metrics/awesomebar.clipboard_suggestion_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `awesomebar.clipboard_suggestion_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/awesomebar.history_suggestion_clicked/README.md
+++ b/annotations/fenix/metrics/awesomebar.history_suggestion_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `awesomebar.history_suggestion_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/awesomebar.opened_tab_suggestion_clicked/README.md
+++ b/annotations/fenix/metrics/awesomebar.opened_tab_suggestion_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `awesomebar.opened_tab_suggestion_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/awesomebar.search_action_clicked/README.md
+++ b/annotations/fenix/metrics/awesomebar.search_action_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `awesomebar.search_action_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/awesomebar.search_suggestion_clicked/README.md
+++ b/annotations/fenix/metrics/awesomebar.search_suggestion_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `awesomebar.search_suggestion_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/banner_open_in_app.dismissed/README.md
+++ b/annotations/fenix/metrics/banner_open_in_app.dismissed/README.md
@@ -2,7 +2,3 @@
 tags:
   - OpenInApp
 ---
-
-This is a stub commentary for the `banner_open_in_app.dismissed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/banner_open_in_app.displayed/README.md
+++ b/annotations/fenix/metrics/banner_open_in_app.displayed/README.md
@@ -2,7 +2,3 @@
 tags:
   - OpenInApp
 ---
-
-This is a stub commentary for the `banner_open_in_app.displayed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/banner_open_in_app.go_to_settings/README.md
+++ b/annotations/fenix/metrics/banner_open_in_app.go_to_settings/README.md
@@ -2,7 +2,3 @@
 tags:
   - OpenInApp
 ---
-
-This is a stub commentary for the `banner_open_in_app.go_to_settings` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.copied/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.copied/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.copied` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.edited/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.edited/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.edited` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.folder_add/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.folder_add/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.folder_add` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.folder_remove/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.folder_remove/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.folder_remove` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.moved/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.moved/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.moved` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.multi_removed/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.multi_removed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.multi_removed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.open/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.open/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.open` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.open_in_new_tab/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.open_in_new_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.open_in_new_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.open_in_new_tabs/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.open_in_new_tabs/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.open_in_new_tabs` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.open_in_private_tab/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.open_in_private_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.open_in_private_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.open_in_private_tabs/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.open_in_private_tabs/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.open_in_private_tabs` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.removed/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.removed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.removed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/bookmarks_management.shared/README.md
+++ b/annotations/fenix/metrics/bookmarks_management.shared/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `bookmarks_management.shared` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/browser.search.ad_clicks/README.md
+++ b/annotations/fenix/metrics/browser.search.ad_clicks/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `browser.search.ad_clicks` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/browser.search.with_ads/README.md
+++ b/annotations/fenix/metrics/browser.search.with_ads/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `browser.search.with_ads` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.add_tab_button/README.md
+++ b/annotations/fenix/metrics/collections.add_tab_button/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.add_tab_button` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.all_tabs_restored/README.md
+++ b/annotations/fenix/metrics/collections.all_tabs_restored/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.all_tabs_restored` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.long_press/README.md
+++ b/annotations/fenix/metrics/collections.long_press/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.long_press` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.removed/README.md
+++ b/annotations/fenix/metrics/collections.removed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.removed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.rename_button/README.md
+++ b/annotations/fenix/metrics/collections.rename_button/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.rename_button` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.renamed/README.md
+++ b/annotations/fenix/metrics/collections.renamed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.renamed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.save_button/README.md
+++ b/annotations/fenix/metrics/collections.save_button/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.save_button` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.saved/README.md
+++ b/annotations/fenix/metrics/collections.saved/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.saved` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.shared/README.md
+++ b/annotations/fenix/metrics/collections.shared/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.shared` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.tab_removed/README.md
+++ b/annotations/fenix/metrics/collections.tab_removed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.tab_removed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.tab_restored/README.md
+++ b/annotations/fenix/metrics/collections.tab_restored/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.tab_restored` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.tab_select_opened/README.md
+++ b/annotations/fenix/metrics/collections.tab_select_opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.tab_select_opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/collections.tabs_added/README.md
+++ b/annotations/fenix/metrics/collections.tabs_added/README.md
@@ -2,7 +2,3 @@
 tags:
   - Collections
 ---
-
-This is a stub commentary for the `collections.tabs_added` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/context_menu.item_tapped/README.md
+++ b/annotations/fenix/metrics/context_menu.item_tapped/README.md
@@ -2,7 +2,3 @@
 tags:
   - Sharing
 ---
-
-This is a stub commentary for the `context_menu.item_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_hint.tracking_protection.dismiss/README.md
+++ b/annotations/fenix/metrics/contextual_hint.tracking_protection.dismiss/README.md
@@ -2,7 +2,3 @@
 tags:
   - TrackingProtection
 ---
-
-This is a stub commentary for the `contextual_hint.tracking_protection.dismiss` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_hint.tracking_protection.display/README.md
+++ b/annotations/fenix/metrics/contextual_hint.tracking_protection.display/README.md
@@ -2,7 +2,3 @@
 tags:
   - TrackingProtection
 ---
-
-This is a stub commentary for the `contextual_hint.tracking_protection.display` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_hint.tracking_protection.inside_tap/README.md
+++ b/annotations/fenix/metrics/contextual_hint.tracking_protection.inside_tap/README.md
@@ -2,7 +2,3 @@
 tags:
   - TrackingProtection
 ---
-
-This is a stub commentary for the `contextual_hint.tracking_protection.inside_tap` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_hint.tracking_protection.outside_tap/README.md
+++ b/annotations/fenix/metrics/contextual_hint.tracking_protection.outside_tap/README.md
@@ -2,7 +2,3 @@
 tags:
   - TrackingProtection
 ---
-
-This is a stub commentary for the `contextual_hint.tracking_protection.outside_tap` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_menu.copy_tapped/README.md
+++ b/annotations/fenix/metrics/contextual_menu.copy_tapped/README.md
@@ -3,7 +3,3 @@ tags:
   - ContextMenu
   - TextSelection
 ---
-
-This is a stub commentary for the `contextual_menu.copy_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_menu.long_press_tapped/README.md
+++ b/annotations/fenix/metrics/contextual_menu.long_press_tapped/README.md
@@ -3,7 +3,3 @@ tags:
   - ContextMenu
   - TextSelection
 ---
-
-This is a stub commentary for the `contextual_menu.long_press_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_menu.search_tapped/README.md
+++ b/annotations/fenix/metrics/contextual_menu.search_tapped/README.md
@@ -3,7 +3,3 @@ tags:
   - ContextMenu
   - TextSelection
 ---
-
-This is a stub commentary for the `contextual_menu.search_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_menu.select_all_tapped/README.md
+++ b/annotations/fenix/metrics/contextual_menu.select_all_tapped/README.md
@@ -3,7 +3,3 @@ tags:
   - ContextMenu
   - TextSelection
 ---
-
-This is a stub commentary for the `contextual_menu.select_all_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/contextual_menu.share_tapped/README.md
+++ b/annotations/fenix/metrics/contextual_menu.share_tapped/README.md
@@ -3,7 +3,3 @@ tags:
   - ContextMenu
   - TextSelection
 ---
-
-This is a stub commentary for the `contextual_menu.share_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/crash_reporter.closed/README.md
+++ b/annotations/fenix/metrics/crash_reporter.closed/README.md
@@ -2,7 +2,3 @@
 tags:
   - CrashReporting
 ---
-
-This is a stub commentary for the `crash_reporter.closed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/crash_reporter.opened/README.md
+++ b/annotations/fenix/metrics/crash_reporter.opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - CrashReporting
 ---
-
-This is a stub commentary for the `crash_reporter.opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/custom_tab.action_button/README.md
+++ b/annotations/fenix/metrics/custom_tab.action_button/README.md
@@ -2,7 +2,3 @@
 tags:
   - CustomTabs
 ---
-
-This is a stub commentary for the `custom_tab.action_button` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/custom_tab.closed/README.md
+++ b/annotations/fenix/metrics/custom_tab.closed/README.md
@@ -2,7 +2,3 @@
 tags:
   - CustomTabs
 ---
-
-This is a stub commentary for the `custom_tab.closed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/custom_tab.menu/README.md
+++ b/annotations/fenix/metrics/custom_tab.menu/README.md
@@ -2,7 +2,3 @@
 tags:
   - CustomTabs
 ---
-
-This is a stub commentary for the `custom_tab.menu` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/download_notification.cancel/README.md
+++ b/annotations/fenix/metrics/download_notification.cancel/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `download_notification.cancel` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/download_notification.in_app_open/README.md
+++ b/annotations/fenix/metrics/download_notification.in_app_open/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `download_notification.in_app_open` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/download_notification.in_app_try_again/README.md
+++ b/annotations/fenix/metrics/download_notification.in_app_try_again/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `download_notification.in_app_try_again` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/download_notification.open/README.md
+++ b/annotations/fenix/metrics/download_notification.open/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `download_notification.open` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/download_notification.pause/README.md
+++ b/annotations/fenix/metrics/download_notification.pause/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `download_notification.pause` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/download_notification.resume/README.md
+++ b/annotations/fenix/metrics/download_notification.resume/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `download_notification.resume` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/download_notification.try_again/README.md
+++ b/annotations/fenix/metrics/download_notification.try_again/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `download_notification.try_again` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/downloads_management.downloads_screen_opened/README.md
+++ b/annotations/fenix/metrics/downloads_management.downloads_screen_opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `downloads_management.downloads_screen_opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/downloads_management.item_deleted/README.md
+++ b/annotations/fenix/metrics/downloads_management.item_deleted/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `downloads_management.item_deleted` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/downloads_management.item_opened/README.md
+++ b/annotations/fenix/metrics/downloads_management.item_opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `downloads_management.item_opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/downloads_misc.download_added/README.md
+++ b/annotations/fenix/metrics/downloads_misc.download_added/README.md
@@ -2,7 +2,3 @@
 tags:
   - Download
 ---
-
-This is a stub commentary for the `downloads_misc.download_added` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/engine.kill_background_age/README.md
+++ b/annotations/fenix/metrics/engine.kill_background_age/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `engine.kill_background_age` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/engine.kill_foreground_age/README.md
+++ b/annotations/fenix/metrics/engine.kill_foreground_age/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `engine.kill_foreground_age` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/engine.tab_kills/README.md
+++ b/annotations/fenix/metrics/engine.tab_kills/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `engine.tab_kills` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/engine_tab.foreground_metrics/README.md
+++ b/annotations/fenix/metrics/engine_tab.foreground_metrics/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `engine_tab.foreground_metrics` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/engine_tab.kill_background_age/README.md
+++ b/annotations/fenix/metrics/engine_tab.kill_background_age/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `engine_tab.kill_background_age` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/engine_tab.kill_foreground_age/README.md
+++ b/annotations/fenix/metrics/engine_tab.kill_foreground_age/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `engine_tab.kill_foreground_age` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/engine_tab.kills/README.md
+++ b/annotations/fenix/metrics/engine_tab.kills/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `engine_tab.kills` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/error_page.visited_error/README.md
+++ b/annotations/fenix/metrics/error_page.visited_error/README.md
@@ -2,7 +2,3 @@
 tags:
   - ErrorMessages
 ---
-
-This is a stub commentary for the `error_page.visited_error` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.app_opened/README.md
+++ b/annotations/fenix/metrics/events.app_opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `events.app_opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.app_opened_all_startup/README.md
+++ b/annotations/fenix/metrics/events.app_opened_all_startup/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `events.app_opened_all_startup` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.app_received_intent/README.md
+++ b/annotations/fenix/metrics/events.app_received_intent/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `events.app_received_intent` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.copy_url_tapped/README.md
+++ b/annotations/fenix/metrics/events.copy_url_tapped/README.md
@@ -2,7 +2,3 @@
 tags:
   - ContextMenu
 ---
-
-This is a stub commentary for the `events.copy_url_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.default_browser_changed/README.md
+++ b/annotations/fenix/metrics/events.default_browser_changed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Toolbar
 ---
-
-This is a stub commentary for the `events.default_browser_changed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.entered_url/README.md
+++ b/annotations/fenix/metrics/events.entered_url/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `events.entered_url` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.normal_and_private_uri_count/README.md
+++ b/annotations/fenix/metrics/events.normal_and_private_uri_count/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `events.normal_and_private_uri_count` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.opened_link/README.md
+++ b/annotations/fenix/metrics/events.opened_link/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `events.opened_link` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.performed_search/README.md
+++ b/annotations/fenix/metrics/events.performed_search/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `events.performed_search` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.preference_toggled/README.md
+++ b/annotations/fenix/metrics/events.preference_toggled/README.md
@@ -6,7 +6,3 @@ tags:
   - PrivateBrowsing
   - Search
 ---
-
-This is a stub commentary for the `events.preference_toggled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.recently_closed_tabs_opened/README.md
+++ b/annotations/fenix/metrics/events.recently_closed_tabs_opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `events.recently_closed_tabs_opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.search_bar_tapped/README.md
+++ b/annotations/fenix/metrics/events.search_bar_tapped/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `events.search_bar_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.synced_tab_opened/README.md
+++ b/annotations/fenix/metrics/events.synced_tab_opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - SyncTabs
 ---
-
-This is a stub commentary for the `events.synced_tab_opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.tab_counter_menu_action/README.md
+++ b/annotations/fenix/metrics/events.tab_counter_menu_action/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `events.tab_counter_menu_action` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.toolbar_menu_visible/README.md
+++ b/annotations/fenix/metrics/events.toolbar_menu_visible/README.md
@@ -2,7 +2,3 @@
 tags:
   - Toolbar
 ---
-
-This is a stub commentary for the `events.toolbar_menu_visible` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/events.total_uri_count/README.md
+++ b/annotations/fenix/metrics/events.total_uri_count/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `events.total_uri_count` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/find_in_page.closed/README.md
+++ b/annotations/fenix/metrics/find_in_page.closed/README.md
@@ -2,7 +2,3 @@
 tags:
   - FindBar
 ---
-
-This is a stub commentary for the `find_in_page.closed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/find_in_page.opened/README.md
+++ b/annotations/fenix/metrics/find_in_page.opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - FindBar
 ---
-
-This is a stub commentary for the `find_in_page.opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/find_in_page.searched_page/README.md
+++ b/annotations/fenix/metrics/find_in_page.searched_page/README.md
@@ -2,7 +2,3 @@
 tags:
   - FindBar
 ---
-
-This is a stub commentary for the `find_in_page.searched_page` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/first_session.adgroup/README.md
+++ b/annotations/fenix/metrics/first_session.adgroup/README.md
@@ -2,7 +2,3 @@
 tags:
   - Telemetry
 ---
-
-This is a stub commentary for the `first_session.adgroup` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/first_session.campaign/README.md
+++ b/annotations/fenix/metrics/first_session.campaign/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `first_session.campaign` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/first_session.creative/README.md
+++ b/annotations/fenix/metrics/first_session.creative/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `first_session.creative` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/first_session.network/README.md
+++ b/annotations/fenix/metrics/first_session.network/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `first_session.network` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/first_session.timestamp/README.md
+++ b/annotations/fenix/metrics/first_session.timestamp/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `first_session.timestamp` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/history.opened/README.md
+++ b/annotations/fenix/metrics/history.opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - History
 ---
-
-This is a stub commentary for the `history.opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/history.opened_item/README.md
+++ b/annotations/fenix/metrics/history.opened_item/README.md
@@ -2,7 +2,3 @@
 tags:
   - History
 ---
-
-This is a stub commentary for the `history.opened_item` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/history.opened_item_in_new_tab/README.md
+++ b/annotations/fenix/metrics/history.opened_item_in_new_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - History
 ---
-
-This is a stub commentary for the `history.opened_item_in_new_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/history.opened_item_in_private_tab/README.md
+++ b/annotations/fenix/metrics/history.opened_item_in_private_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - History
 ---
-
-This is a stub commentary for the `history.opened_item_in_private_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/history.opened_items_in_new_tabs/README.md
+++ b/annotations/fenix/metrics/history.opened_items_in_new_tabs/README.md
@@ -2,7 +2,3 @@
 tags:
   - History
 ---
-
-This is a stub commentary for the `history.opened_items_in_new_tabs` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/history.opened_items_in_private_tabs/README.md
+++ b/annotations/fenix/metrics/history.opened_items_in_private_tabs/README.md
@@ -2,7 +2,3 @@
 tags:
   - History
 ---
-
-This is a stub commentary for the `history.opened_items_in_private_tabs` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/history.removed/README.md
+++ b/annotations/fenix/metrics/history.removed/README.md
@@ -2,7 +2,3 @@
 tags:
   - History
 ---
-
-This is a stub commentary for the `history.removed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/history.removed_all/README.md
+++ b/annotations/fenix/metrics/history.removed_all/README.md
@@ -2,7 +2,3 @@
 tags:
   - History
 ---
-
-This is a stub commentary for the `history.removed_all` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/history.shared/README.md
+++ b/annotations/fenix/metrics/history.shared/README.md
@@ -2,7 +2,3 @@
 tags:
   - History
 ---
-
-This is a stub commentary for the `history.shared` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/home_menu.settings_item_clicked/README.md
+++ b/annotations/fenix/metrics/home_menu.settings_item_clicked/README.md
@@ -3,7 +3,3 @@ tags:
   - Settings
   - MainMenu
 ---
-
-This is a stub commentary for the `{}` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/home_screen.home_screen_displayed/README.md
+++ b/annotations/fenix/metrics/home_screen.home_screen_displayed/README.md
@@ -3,7 +3,3 @@ tags:
   - Settings
   - MainMenu
 ---
-
-This is a stub commentary for the `{}` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/login_dialog.cancelled/README.md
+++ b/annotations/fenix/metrics/login_dialog.cancelled/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `login_dialog.cancelled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/login_dialog.displayed/README.md
+++ b/annotations/fenix/metrics/login_dialog.displayed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `login_dialog.displayed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/login_dialog.never_save/README.md
+++ b/annotations/fenix/metrics/login_dialog.never_save/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `login_dialog.never_save` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/login_dialog.saved/README.md
+++ b/annotations/fenix/metrics/login_dialog.saved/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `login_dialog.saved` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/logins.copy_login/README.md
+++ b/annotations/fenix/metrics/logins.copy_login/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `logins.copy_login` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/logins.delete_saved_login/README.md
+++ b/annotations/fenix/metrics/logins.delete_saved_login/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `logins.delete_saved_login` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/logins.open_individual_login/README.md
+++ b/annotations/fenix/metrics/logins.open_individual_login/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `logins.open_individual_login` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/logins.open_login_editor/README.md
+++ b/annotations/fenix/metrics/logins.open_login_editor/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `logins.open_login_editor` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/logins.open_logins/README.md
+++ b/annotations/fenix/metrics/logins.open_logins/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `logins.open_logins` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/logins.save_edited_login/README.md
+++ b/annotations/fenix/metrics/logins.save_edited_login/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `logins.save_edited_login` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/logins.save_logins_setting_changed/README.md
+++ b/annotations/fenix/metrics/logins.save_logins_setting_changed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `logins.save_logins_setting_changed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/logins.view_password_login/README.md
+++ b/annotations/fenix/metrics/logins.view_password_login/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `logins.view_password_login` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/master_password.displayed/README.md
+++ b/annotations/fenix/metrics/master_password.displayed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Migration
 ---
-
-This is a stub commentary for the `master_password.displayed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/master_password.migration/README.md
+++ b/annotations/fenix/metrics/master_password.migration/README.md
@@ -2,7 +2,3 @@
 tags:
   - Migration
 ---
-
-This is a stub commentary for the `master_password.migration` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/media_notification.pause/README.md
+++ b/annotations/fenix/metrics/media_notification.pause/README.md
@@ -2,7 +2,3 @@
 tags:
   - Media
 ---
-
-This is a stub commentary for the `media_notification.pause` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/media_notification.play/README.md
+++ b/annotations/fenix/metrics/media_notification.play/README.md
@@ -2,7 +2,3 @@
 tags:
   - Media
 ---
-
-This is a stub commentary for the `media_notification.play` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/media_state.fullscreen/README.md
+++ b/annotations/fenix/metrics/media_state.fullscreen/README.md
@@ -2,7 +2,3 @@
 tags:
   - Media
 ---
-
-This is a stub commentary for the `media_state.fullscreen` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/media_state.pause/README.md
+++ b/annotations/fenix/metrics/media_state.pause/README.md
@@ -2,7 +2,3 @@
 tags:
   - Media
 ---
-
-This is a stub commentary for the `media_state.pause` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/media_state.picture_in_picture/README.md
+++ b/annotations/fenix/metrics/media_state.picture_in_picture/README.md
@@ -2,7 +2,3 @@
 tags:
   - Media
 ---
-
-This is a stub commentary for the `media_state.picture_in_picture` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/media_state.play/README.md
+++ b/annotations/fenix/metrics/media_state.play/README.md
@@ -2,7 +2,3 @@
 tags:
   - Media
 ---
-
-This is a stub commentary for the `media_state.play` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/media_state.stop/README.md
+++ b/annotations/fenix/metrics/media_state.stop/README.md
@@ -2,7 +2,3 @@
 tags:
   - Media
 ---
-
-This is a stub commentary for the `media_state.stop` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.activity_state_provider_error/README.md
+++ b/annotations/fenix/metrics/metrics.activity_state_provider_error/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `metrics.activity_state_provider_error` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.adjust_ad_group/README.md
+++ b/annotations/fenix/metrics/metrics.adjust_ad_group/README.md
@@ -2,7 +2,3 @@
 tags:
   - Telemetry
 ---
-
-This is a stub commentary for the `metrics.adjust_ad_group` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.adjust_campaign/README.md
+++ b/annotations/fenix/metrics/metrics.adjust_campaign/README.md
@@ -2,7 +2,3 @@
 tags:
   - Telemetry
 ---
-
-This is a stub commentary for the `metrics.adjust_campaign` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.adjust_creative/README.md
+++ b/annotations/fenix/metrics/metrics.adjust_creative/README.md
@@ -2,7 +2,3 @@
 tags:
   - Telemetry
 ---
-
-This is a stub commentary for the `metrics.adjust_creative` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.adjust_network/README.md
+++ b/annotations/fenix/metrics/metrics.adjust_network/README.md
@@ -2,7 +2,3 @@
 tags:
   - Telemetry
 ---
-
-This is a stub commentary for the `metrics.adjust_network` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.close_tab_setting/README.md
+++ b/annotations/fenix/metrics/metrics.close_tab_setting/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `metrics.close_tab_setting` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.default_browser/README.md
+++ b/annotations/fenix/metrics/metrics.default_browser/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `metrics.default_browser` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.default_moz_browser/README.md
+++ b/annotations/fenix/metrics/metrics.default_moz_browser/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `metrics.default_moz_browser` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.desktop_bookmarks_count/README.md
+++ b/annotations/fenix/metrics/metrics.desktop_bookmarks_count/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `metrics.desktop_bookmarks_count` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.distribution_id/README.md
+++ b/annotations/fenix/metrics/metrics.distribution_id/README.md
@@ -2,7 +2,3 @@
 tags:
   - China
 ---
-
-This is a stub commentary for the `metrics.distribution_id` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.has_desktop_bookmarks/README.md
+++ b/annotations/fenix/metrics/metrics.has_desktop_bookmarks/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `metrics.has_desktop_bookmarks` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.has_mobile_bookmarks/README.md
+++ b/annotations/fenix/metrics/metrics.has_mobile_bookmarks/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `metrics.has_mobile_bookmarks` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.has_open_tabs/README.md
+++ b/annotations/fenix/metrics/metrics.has_open_tabs/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `metrics.has_open_tabs` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.has_recent_pwas/README.md
+++ b/annotations/fenix/metrics/metrics.has_recent_pwas/README.md
@@ -2,7 +2,3 @@
 tags:
   - PWA
 ---
-
-This is a stub commentary for the `metrics.has_recent_pwas` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.has_top_sites/README.md
+++ b/annotations/fenix/metrics/metrics.has_top_sites/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `metrics.has_top_sites` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.mobile_bookmarks_count/README.md
+++ b/annotations/fenix/metrics/metrics.mobile_bookmarks_count/README.md
@@ -2,7 +2,3 @@
 tags:
   - Bookmarks
 ---
-
-This is a stub commentary for the `metrics.mobile_bookmarks_count` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.mozilla_products/README.md
+++ b/annotations/fenix/metrics/metrics.mozilla_products/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `metrics.mozilla_products` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.recently_used_pwa_count/README.md
+++ b/annotations/fenix/metrics/metrics.recently_used_pwa_count/README.md
@@ -2,7 +2,3 @@
 tags:
   - PWA
 ---
-
-This is a stub commentary for the `metrics.recently_used_pwa_count` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.search_widget_installed/README.md
+++ b/annotations/fenix/metrics/metrics.search_widget_installed/README.md
@@ -3,7 +3,3 @@ tags:
   - Discovery
   - Search
 ---
-
-This is a stub commentary for the `metrics.search_widget_installed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.start_reason_activity_error/README.md
+++ b/annotations/fenix/metrics/metrics.start_reason_activity_error/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `metrics.start_reason_activity_error` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.start_reason_process_error/README.md
+++ b/annotations/fenix/metrics/metrics.start_reason_process_error/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `metrics.start_reason_process_error` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.tabs_open_count/README.md
+++ b/annotations/fenix/metrics/metrics.tabs_open_count/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `metrics.tabs_open_count` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.toolbar_position/README.md
+++ b/annotations/fenix/metrics/metrics.toolbar_position/README.md
@@ -2,7 +2,3 @@
 tags:
   - Toolbar
 ---
-
-This is a stub commentary for the `metrics.toolbar_position` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/metrics.top_sites_count/README.md
+++ b/annotations/fenix/metrics/metrics.top_sites_count/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `metrics.top_sites_count` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/onboarding.finish/README.md
+++ b/annotations/fenix/metrics/onboarding.finish/README.md
@@ -2,7 +2,3 @@
 tags:
   - Onboarding
 ---
-
-This is a stub commentary for the `onboarding.finish` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/onboarding.fxa_auto_signin/README.md
+++ b/annotations/fenix/metrics/onboarding.fxa_auto_signin/README.md
@@ -2,7 +2,3 @@
 tags:
   - Onboarding
 ---
-
-This is a stub commentary for the `onboarding.fxa_auto_signin` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/onboarding.fxa_manual_signin/README.md
+++ b/annotations/fenix/metrics/onboarding.fxa_manual_signin/README.md
@@ -2,7 +2,3 @@
 tags:
   - Onboarding
 ---
-
-This is a stub commentary for the `onboarding.fxa_manual_signin` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/onboarding.pref_toggled_private_browsing/README.md
+++ b/annotations/fenix/metrics/onboarding.pref_toggled_private_browsing/README.md
@@ -2,7 +2,3 @@
 tags:
   - Onboarding
 ---
-
-This is a stub commentary for the `onboarding.pref_toggled_private_browsing` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/onboarding.pref_toggled_theme_picker/README.md
+++ b/annotations/fenix/metrics/onboarding.pref_toggled_theme_picker/README.md
@@ -2,7 +2,3 @@
 tags:
   - Onboarding
 ---
-
-This is a stub commentary for the `onboarding.pref_toggled_theme_picker` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/onboarding.pref_toggled_toolbar_position/README.md
+++ b/annotations/fenix/metrics/onboarding.pref_toggled_toolbar_position/README.md
@@ -2,7 +2,3 @@
 tags:
   - Onboarding
 ---
-
-This is a stub commentary for the `onboarding.pref_toggled_toolbar_position` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/onboarding.pref_toggled_tracking_prot/README.md
+++ b/annotations/fenix/metrics/onboarding.pref_toggled_tracking_prot/README.md
@@ -2,7 +2,3 @@
 tags:
   - Onboarding
 ---
-
-This is a stub commentary for the `onboarding.pref_toggled_tracking_prot` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/onboarding.privacy_notice/README.md
+++ b/annotations/fenix/metrics/onboarding.privacy_notice/README.md
@@ -2,7 +2,3 @@
 tags:
   - Onboarding
 ---
-
-This is a stub commentary for the `onboarding.privacy_notice` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/onboarding.whats_new/README.md
+++ b/annotations/fenix/metrics/onboarding.whats_new/README.md
@@ -2,7 +2,3 @@
 tags:
   - Onboarding
 ---
-
-This is a stub commentary for the `onboarding.whats_new` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.bookmark_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.bookmark_suggestions/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.awesomebar.bookmark_suggestions` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.clipboard_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.clipboard_suggestions/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.awesomebar.clipboard_suggestions` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.history_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.history_suggestions/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.awesomebar.history_suggestions` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.search_engine_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.search_engine_suggestions/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.awesomebar.search_engine_suggestions` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.session_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.session_suggestions/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.awesomebar.session_suggestions` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.shortcuts_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.shortcuts_suggestions/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.awesomebar.shortcuts_suggestions` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.awesomebar.synced_tabs_suggestions/README.md
+++ b/annotations/fenix/metrics/perf.awesomebar.synced_tabs_suggestions/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.awesomebar.synced_tabs_suggestions` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.app_on_create_to_glean_init/README.md
+++ b/annotations/fenix/metrics/perf.startup.app_on_create_to_glean_init/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.app_on_create_to_glean_init` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.app_on_create_to_megazord_init/README.md
+++ b/annotations/fenix/metrics/perf.startup.app_on_create_to_megazord_init/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.app_on_create_to_megazord_init` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.app_on_create_to_setup_in_main/README.md
+++ b/annotations/fenix/metrics/perf.startup.app_on_create_to_setup_in_main/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.app_on_create_to_setup_in_main` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.application_on_create/README.md
+++ b/annotations/fenix/metrics/perf.startup.application_on_create/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.application_on_create` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.base_bfragment_on_create_view/README.md
+++ b/annotations/fenix/metrics/perf.startup.base_bfragment_on_create_view/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.base_bfragment_on_create_view` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.base_bfragment_on_view_created/README.md
+++ b/annotations/fenix/metrics/perf.startup.base_bfragment_on_view_created/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.base_bfragment_on_view_created` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.cold_main_app_to_first_frame/README.md
+++ b/annotations/fenix/metrics/perf.startup.cold_main_app_to_first_frame/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.cold_main_app_to_first_frame` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.cold_unknwn_app_to_first_frame/README.md
+++ b/annotations/fenix/metrics/perf.startup.cold_unknwn_app_to_first_frame/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.cold_unknwn_app_to_first_frame` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.cold_view_app_to_first_frame/README.md
+++ b/annotations/fenix/metrics/perf.startup.cold_view_app_to_first_frame/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.cold_view_app_to_first_frame` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.home_activity_on_create/README.md
+++ b/annotations/fenix/metrics/perf.startup.home_activity_on_create/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.home_activity_on_create` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.home_activity_on_start/README.md
+++ b/annotations/fenix/metrics/perf.startup.home_activity_on_start/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.home_activity_on_start` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.home_fragment_on_create_view/README.md
+++ b/annotations/fenix/metrics/perf.startup.home_fragment_on_create_view/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.home_fragment_on_create_view` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/perf.startup.home_fragment_on_view_created/README.md
+++ b/annotations/fenix/metrics/perf.startup.home_fragment_on_view_created/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `perf.startup.home_fragment_on_view_created` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/pocket.pocket_top_site_clicked/README.md
+++ b/annotations/fenix/metrics/pocket.pocket_top_site_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `pocket.pocket_top_site_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/pocket.pocket_top_site_removed/README.md
+++ b/annotations/fenix/metrics/pocket.pocket_top_site_removed/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `pocket.pocket_top_site_removed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.accessibility_services/README.md
+++ b/annotations/fenix/metrics/preferences.accessibility_services/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `preferences.accessibility_services` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.bookmarks_suggestion/README.md
+++ b/annotations/fenix/metrics/preferences.bookmarks_suggestion/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `preferences.bookmarks_suggestion` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.browsing_history_suggestion/README.md
+++ b/annotations/fenix/metrics/preferences.browsing_history_suggestion/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `preferences.browsing_history_suggestion` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.clipboard_suggestions_enabled/README.md
+++ b/annotations/fenix/metrics/preferences.clipboard_suggestions_enabled/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `preferences.clipboard_suggestions_enabled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.enhanced_tracking_protection/README.md
+++ b/annotations/fenix/metrics/preferences.enhanced_tracking_protection/README.md
@@ -3,7 +3,3 @@ tags:
   - TrackingProtection
   - Settings
 ---
-
-This is a stub commentary for the `preferences.enhanced_tracking_protection` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.open_links_in_app_enabled/README.md
+++ b/annotations/fenix/metrics/preferences.open_links_in_app_enabled/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `preferences.open_links_in_app_enabled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.open_links_in_private/README.md
+++ b/annotations/fenix/metrics/preferences.open_links_in_private/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `preferences.open_links_in_private` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.private_search_suggestions/README.md
+++ b/annotations/fenix/metrics/preferences.private_search_suggestions/README.md
@@ -3,7 +3,3 @@ tags:
   - Search
   - Settings
 ---
-
-This is a stub commentary for the `preferences.private_search_suggestions` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.remote_debugging_enabled/README.md
+++ b/annotations/fenix/metrics/preferences.remote_debugging_enabled/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `preferences.remote_debugging_enabled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.search_shortcuts_enabled/README.md
+++ b/annotations/fenix/metrics/preferences.search_shortcuts_enabled/README.md
@@ -3,7 +3,3 @@ tags:
   - Search
   - Settings
 ---
-
-This is a stub commentary for the `preferences.search_shortcuts_enabled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.search_suggestions_enabled/README.md
+++ b/annotations/fenix/metrics/preferences.search_suggestions_enabled/README.md
@@ -3,7 +3,3 @@ tags:
   - Search
   - Settings
 ---
-
-This is a stub commentary for the `preferences.search_suggestions_enabled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.signed_in_sync/README.md
+++ b/annotations/fenix/metrics/preferences.signed_in_sync/README.md
@@ -3,7 +3,3 @@ tags:
   - Sync
   - Settings
 ---
-
-This is a stub commentary for the `preferences.signed_in_sync` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.sync_items/README.md
+++ b/annotations/fenix/metrics/preferences.sync_items/README.md
@@ -2,7 +2,3 @@
 tags:
   - Settings
 ---
-
-This is a stub commentary for the `preferences.sync_items` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.telemetry_enabled/README.md
+++ b/annotations/fenix/metrics/preferences.telemetry_enabled/README.md
@@ -3,7 +3,3 @@ tags:
   - Telemetry
   - Settings
 ---
-
-This is a stub commentary for the `preferences.telemetry_enabled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.toolbar_position_setting/README.md
+++ b/annotations/fenix/metrics/preferences.toolbar_position_setting/README.md
@@ -3,7 +3,3 @@ tags:
   - Toolbar
   - Settings
 ---
-
-This is a stub commentary for the `preferences.toolbar_position_setting` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.user_theme/README.md
+++ b/annotations/fenix/metrics/preferences.user_theme/README.md
@@ -3,7 +3,3 @@ tags:
   - Themes
   - Settings
 ---
-
-This is a stub commentary for the `preferences.user_theme` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/preferences.voice_search_enabled/README.md
+++ b/annotations/fenix/metrics/preferences.voice_search_enabled/README.md
@@ -4,7 +4,3 @@ tags:
   - Voice
   - Settings
 ---
-
-This is a stub commentary for the `preferences.voice_search_enabled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_mode.garbage_icon/README.md
+++ b/annotations/fenix/metrics/private_browsing_mode.garbage_icon/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_mode.garbage_icon` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_mode.notification_delete/README.md
+++ b/annotations/fenix/metrics/private_browsing_mode.notification_delete/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_mode.notification_delete` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_mode.notification_open/README.md
+++ b/annotations/fenix/metrics/private_browsing_mode.notification_open/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_mode.notification_open` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_mode.notification_tapped/README.md
+++ b/annotations/fenix/metrics/private_browsing_mode.notification_tapped/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_mode.notification_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_mode.snackbar_undo/README.md
+++ b/annotations/fenix/metrics/private_browsing_mode.snackbar_undo/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_mode.snackbar_undo` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.cfr_add_shortcut/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.cfr_add_shortcut/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_shortcut.cfr_add_shortcut` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.cfr_cancel/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.cfr_cancel/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_shortcut.cfr_cancel` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.create_shortcut/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.create_shortcut/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_shortcut.create_shortcut` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.pinned_shortcut_priv/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.pinned_shortcut_priv/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_shortcut.pinned_shortcut_priv` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.static_shortcut_priv/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.static_shortcut_priv/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_shortcut.static_shortcut_priv` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/private_browsing_shortcut.static_shortcut_tab/README.md
+++ b/annotations/fenix/metrics/private_browsing_shortcut.static_shortcut_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - PrivateBrowsing
 ---
-
-This is a stub commentary for the `private_browsing_shortcut.static_shortcut_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/progressive_web_app.background/README.md
+++ b/annotations/fenix/metrics/progressive_web_app.background/README.md
@@ -2,7 +2,3 @@
 tags:
   - PWA
 ---
-
-This is a stub commentary for the `progressive_web_app.background` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/progressive_web_app.foreground/README.md
+++ b/annotations/fenix/metrics/progressive_web_app.foreground/README.md
@@ -2,7 +2,3 @@
 tags:
   - PWA
 ---
-
-This is a stub commentary for the `progressive_web_app.foreground` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/progressive_web_app.homescreen_tap/README.md
+++ b/annotations/fenix/metrics/progressive_web_app.homescreen_tap/README.md
@@ -2,7 +2,3 @@
 tags:
   - PWA
 ---
-
-This is a stub commentary for the `progressive_web_app.homescreen_tap` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/progressive_web_app.install_tap/README.md
+++ b/annotations/fenix/metrics/progressive_web_app.install_tap/README.md
@@ -2,7 +2,3 @@
 tags:
   - PWA
 ---
-
-This is a stub commentary for the `progressive_web_app.install_tap` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/qr_scanner.navigation_allowed/README.md
+++ b/annotations/fenix/metrics/qr_scanner.navigation_allowed/README.md
@@ -2,7 +2,3 @@
 tags:
   - QRCode
 ---
-
-This is a stub commentary for the `qr_scanner.navigation_allowed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/qr_scanner.navigation_denied/README.md
+++ b/annotations/fenix/metrics/qr_scanner.navigation_denied/README.md
@@ -2,7 +2,3 @@
 tags:
   - QRCode
 ---
-
-This is a stub commentary for the `qr_scanner.navigation_denied` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/qr_scanner.opened/README.md
+++ b/annotations/fenix/metrics/qr_scanner.opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - QRCode
 ---
-
-This is a stub commentary for the `qr_scanner.opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/qr_scanner.prompt_displayed/README.md
+++ b/annotations/fenix/metrics/qr_scanner.prompt_displayed/README.md
@@ -2,7 +2,3 @@
 tags:
   - QRCode
 ---
-
-This is a stub commentary for the `qr_scanner.prompt_displayed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/reader_mode.appearance/README.md
+++ b/annotations/fenix/metrics/reader_mode.appearance/README.md
@@ -2,7 +2,3 @@
 tags:
   - ReaderMode
 ---
-
-This is a stub commentary for the `reader_mode.appearance` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/reader_mode.available/README.md
+++ b/annotations/fenix/metrics/reader_mode.available/README.md
@@ -2,7 +2,3 @@
 tags:
   - ReaderMode
 ---
-
-This is a stub commentary for the `reader_mode.available` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/reader_mode.closed/README.md
+++ b/annotations/fenix/metrics/reader_mode.closed/README.md
@@ -2,7 +2,3 @@
 tags:
   - ReaderMode
 ---
-
-This is a stub commentary for the `reader_mode.closed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/reader_mode.opened/README.md
+++ b/annotations/fenix/metrics/reader_mode.opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - ReaderMode
 ---
-
-This is a stub commentary for the `reader_mode.opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search.default_engine.code/README.md
+++ b/annotations/fenix/metrics/search.default_engine.code/README.md
@@ -2,7 +2,3 @@
 tags:
   - SearchProvider
 ---
-
-This is a stub commentary for the `search.default_engine.code` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search.default_engine.name/README.md
+++ b/annotations/fenix/metrics/search.default_engine.name/README.md
@@ -2,7 +2,3 @@
 tags:
   - SearchProvider
 ---
-
-This is a stub commentary for the `search.default_engine.name` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search.default_engine.submission_url/README.md
+++ b/annotations/fenix/metrics/search.default_engine.submission_url/README.md
@@ -2,7 +2,3 @@
 tags:
   - SearchProvider
 ---
-
-This is a stub commentary for the `search.default_engine.submission_url` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search_shortcuts.selected/README.md
+++ b/annotations/fenix/metrics/search_shortcuts.selected/README.md
@@ -2,7 +2,3 @@
 tags:
   - Shortcuts
 ---
-
-This is a stub commentary for the `search_shortcuts.selected` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search_suggestions.enable_in_private/README.md
+++ b/annotations/fenix/metrics/search_suggestions.enable_in_private/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `search_suggestions.enable_in_private` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search_widget.new_tab_button/README.md
+++ b/annotations/fenix/metrics/search_widget.new_tab_button/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `search_widget.new_tab_button` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search_widget.voice_button/README.md
+++ b/annotations/fenix/metrics/search_widget.voice_button/README.md
@@ -2,7 +2,3 @@
 tags:
   - Search
 ---
-
-This is a stub commentary for the `search_widget.voice_button` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search_widget_cfr.add_widget_pressed/README.md
+++ b/annotations/fenix/metrics/search_widget_cfr.add_widget_pressed/README.md
@@ -3,7 +3,3 @@ tags:
   - Discovery
   - Search
 ---
-
-This is a stub commentary for the `search_widget_cfr.add_widget_pressed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search_widget_cfr.canceled/README.md
+++ b/annotations/fenix/metrics/search_widget_cfr.canceled/README.md
@@ -3,7 +3,3 @@ tags:
   - Discovery
   - Search
 ---
-
-This is a stub commentary for the `search_widget_cfr.canceled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search_widget_cfr.displayed/README.md
+++ b/annotations/fenix/metrics/search_widget_cfr.displayed/README.md
@@ -3,7 +3,3 @@ tags:
   - Discovery
   - Search
 ---
-
-This is a stub commentary for the `search_widget_cfr.displayed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/search_widget_cfr.not_now_pressed/README.md
+++ b/annotations/fenix/metrics/search_widget_cfr.not_now_pressed/README.md
@@ -3,7 +3,3 @@ tags:
   - Discovery
   - Search
 ---
-
-This is a stub commentary for the `search_widget_cfr.not_now_pressed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/set_default_newtab_experiment.close_experiment_card_clicked/README.md
+++ b/annotations/fenix/metrics/set_default_newtab_experiment.close_experiment_card_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - Experiments
 ---
-
-This is a stub commentary for the `set_default_newtab_experiment.close_experiment_card_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/set_default_newtab_experiment.set_default_browser_clicked/README.md
+++ b/annotations/fenix/metrics/set_default_newtab_experiment.set_default_browser_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - Experiments
 ---
-
-This is a stub commentary for the `set_default_newtab_experiment.set_default_browser_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/set_default_setting_experiment.set_default_browser_clicked/README.md
+++ b/annotations/fenix/metrics/set_default_setting_experiment.set_default_browser_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - Experiments
 ---
-
-This is a stub commentary for the `set_default_setting_experiment.set_default_browser_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/startup.timeline.clock_ticks_per_second/README.md
+++ b/annotations/fenix/metrics/startup.timeline.clock_ticks_per_second/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `startup.timeline.clock_ticks_per_second` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/startup.timeline.clock_ticks_per_second_v2/README.md
+++ b/annotations/fenix/metrics/startup.timeline.clock_ticks_per_second_v2/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `startup.timeline.clock_ticks_per_second_v2` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/startup.timeline.framework_primary/README.md
+++ b/annotations/fenix/metrics/startup.timeline.framework_primary/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `startup.timeline.framework_primary` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/startup.timeline.framework_secondary/README.md
+++ b/annotations/fenix/metrics/startup.timeline.framework_secondary/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `startup.timeline.framework_secondary` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/startup.timeline.framework_start/README.md
+++ b/annotations/fenix/metrics/startup.timeline.framework_start/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `startup.timeline.framework_start` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/startup.timeline.framework_start_error/README.md
+++ b/annotations/fenix/metrics/startup.timeline.framework_start_error/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `startup.timeline.framework_start_error` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/startup.timeline.framework_start_read_error/README.md
+++ b/annotations/fenix/metrics/startup.timeline.framework_start_read_error/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `startup.timeline.framework_start_read_error` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/storage.stats.app_bytes/README.md
+++ b/annotations/fenix/metrics/storage.stats.app_bytes/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `storage.stats.app_bytes` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/storage.stats.cache_bytes/README.md
+++ b/annotations/fenix/metrics/storage.stats.cache_bytes/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `storage.stats.cache_bytes` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/storage.stats.data_dir_bytes/README.md
+++ b/annotations/fenix/metrics/storage.stats.data_dir_bytes/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `storage.stats.data_dir_bytes` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/storage.stats.query_stats_duration/README.md
+++ b/annotations/fenix/metrics/storage.stats.query_stats_duration/README.md
@@ -2,7 +2,3 @@
 tags:
   - Performance
 ---
-
-This is a stub commentary for the `storage.stats.query_stats_duration` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_account.closed/README.md
+++ b/annotations/fenix/metrics/sync_account.closed/README.md
@@ -3,7 +3,3 @@ tags:
   - Toolbar
   - Sync
 ---
-
-This is a stub commentary for the `sync_account.closed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_account.opened/README.md
+++ b/annotations/fenix/metrics/sync_account.opened/README.md
@@ -3,7 +3,3 @@ tags:
   - Toolbar
   - Sync
 ---
-
-This is a stub commentary for the `sync_account.opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_account.send_tab/README.md
+++ b/annotations/fenix/metrics/sync_account.send_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - SendTab
 ---
-
-This is a stub commentary for the `sync_account.send_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_account.sign_in_to_send_tab/README.md
+++ b/annotations/fenix/metrics/sync_account.sign_in_to_send_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - SendTab
 ---
-
-This is a stub commentary for the `sync_account.sign_in_to_send_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_account.sync_now/README.md
+++ b/annotations/fenix/metrics/sync_account.sync_now/README.md
@@ -3,7 +3,3 @@ tags:
   - Toolbar
   - Sync
 ---
-
-This is a stub commentary for the `sync_account.sync_now` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.auto_login/README.md
+++ b/annotations/fenix/metrics/sync_auth.auto_login/README.md
@@ -2,7 +2,3 @@
 tags:
   - Accounts
 ---
-
-This is a stub commentary for the `sync_auth.auto_login` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.closed/README.md
+++ b/annotations/fenix/metrics/sync_auth.closed/README.md
@@ -3,7 +3,3 @@ tags:
   - Toolbar
   - Sync
 ---
-
-This is a stub commentary for the `sync_auth.closed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.opened/README.md
+++ b/annotations/fenix/metrics/sync_auth.opened/README.md
@@ -3,7 +3,3 @@ tags:
   - Toolbar
   - Sync
 ---
-
-This is a stub commentary for the `sync_auth.opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.other_external/README.md
+++ b/annotations/fenix/metrics/sync_auth.other_external/README.md
@@ -2,7 +2,3 @@
 tags:
   - Accounts
 ---
-
-This is a stub commentary for the `sync_auth.other_external` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.paired/README.md
+++ b/annotations/fenix/metrics/sync_auth.paired/README.md
@@ -2,7 +2,3 @@
 tags:
   - Accounts
 ---
-
-This is a stub commentary for the `sync_auth.paired` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.recovered/README.md
+++ b/annotations/fenix/metrics/sync_auth.recovered/README.md
@@ -2,7 +2,3 @@
 tags:
   - Accounts
 ---
-
-This is a stub commentary for the `sync_auth.recovered` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.scan_pairing/README.md
+++ b/annotations/fenix/metrics/sync_auth.scan_pairing/README.md
@@ -2,7 +2,3 @@
 tags:
   - Sync
 ---
-
-This is a stub commentary for the `sync_auth.scan_pairing` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.sign_in/README.md
+++ b/annotations/fenix/metrics/sync_auth.sign_in/README.md
@@ -2,7 +2,3 @@
 tags:
   - Sync
 ---
-
-This is a stub commentary for the `sync_auth.sign_in` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.sign_out/README.md
+++ b/annotations/fenix/metrics/sync_auth.sign_out/README.md
@@ -2,7 +2,3 @@
 tags:
   - Sync
 ---
-
-This is a stub commentary for the `sync_auth.sign_out` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.sign_up/README.md
+++ b/annotations/fenix/metrics/sync_auth.sign_up/README.md
@@ -2,7 +2,3 @@
 tags:
   - Accounts
 ---
-
-This is a stub commentary for the `sync_auth.sign_up` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.use_email/README.md
+++ b/annotations/fenix/metrics/sync_auth.use_email/README.md
@@ -2,7 +2,3 @@
 tags:
   - Sync
 ---
-
-This is a stub commentary for the `sync_auth.use_email` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/sync_auth.use_email_problem/README.md
+++ b/annotations/fenix/metrics/sync_auth.use_email_problem/README.md
@@ -2,7 +2,3 @@
 tags:
   - Sync
 ---
-
-This is a stub commentary for the `sync_auth.use_email_problem` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/synced_tabs.synced_tabs_suggestion_clicked/README.md
+++ b/annotations/fenix/metrics/synced_tabs.synced_tabs_suggestion_clicked/README.md
@@ -2,7 +2,3 @@
 tags:
   - SyncTabs
 ---
-
-This is a stub commentary for the `synced_tabs.synced_tabs_suggestion_clicked` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tab.media_pause/README.md
+++ b/annotations/fenix/metrics/tab.media_pause/README.md
@@ -2,7 +2,3 @@
 tags:
   - Media
 ---
-
-This is a stub commentary for the `tab.media_pause` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tab.media_play/README.md
+++ b/annotations/fenix/metrics/tab.media_play/README.md
@@ -2,7 +2,3 @@
 tags:
   - Media
 ---
-
-This is a stub commentary for the `tab.media_play` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs.setting_opened/README.md
+++ b/annotations/fenix/metrics/tabs.setting_opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs.setting_opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.cfr.dismiss/README.md
+++ b/annotations/fenix/metrics/tabs_tray.cfr.dismiss/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.cfr.dismiss` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.cfr.go_to_settings/README.md
+++ b/annotations/fenix/metrics/tabs_tray.cfr.go_to_settings/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.cfr.go_to_settings` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.close_all_tabs/README.md
+++ b/annotations/fenix/metrics/tabs_tray.close_all_tabs/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.close_all_tabs` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.closed/README.md
+++ b/annotations/fenix/metrics/tabs_tray.closed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.closed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.closed_existing_tab/README.md
+++ b/annotations/fenix/metrics/tabs_tray.closed_existing_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.closed_existing_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.menu_opened/README.md
+++ b/annotations/fenix/metrics/tabs_tray.menu_opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.menu_opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.new_private_tab_tapped/README.md
+++ b/annotations/fenix/metrics/tabs_tray.new_private_tab_tapped/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.new_private_tab_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.new_tab_tapped/README.md
+++ b/annotations/fenix/metrics/tabs_tray.new_tab_tapped/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.new_tab_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.normal_mode_tapped/README.md
+++ b/annotations/fenix/metrics/tabs_tray.normal_mode_tapped/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.normal_mode_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.opened/README.md
+++ b/annotations/fenix/metrics/tabs_tray.opened/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.opened` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.opened_existing_tab/README.md
+++ b/annotations/fenix/metrics/tabs_tray.opened_existing_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.opened_existing_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.private_mode_tapped/README.md
+++ b/annotations/fenix/metrics/tabs_tray.private_mode_tapped/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.private_mode_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.save_to_collection/README.md
+++ b/annotations/fenix/metrics/tabs_tray.save_to_collection/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.save_to_collection` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.share_all_tabs/README.md
+++ b/annotations/fenix/metrics/tabs_tray.share_all_tabs/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.share_all_tabs` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tabs_tray.synced_mode_tapped/README.md
+++ b/annotations/fenix/metrics/tabs_tray.synced_mode_tapped/README.md
@@ -3,7 +3,3 @@ tags:
   - SyncTabs
   - Tabs
 ---
-
-This is a stub commentary for the `tabs_tray.synced_mode_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tip.closed/README.md
+++ b/annotations/fenix/metrics/tip.closed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Discovery
 ---
-
-This is a stub commentary for the `tip.closed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tip.displayed/README.md
+++ b/annotations/fenix/metrics/tip.displayed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Discovery
 ---
-
-This is a stub commentary for the `tip.displayed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tip.pressed/README.md
+++ b/annotations/fenix/metrics/tip.pressed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Discovery
 ---
-
-This is a stub commentary for the `tip.pressed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/toolbar_settings.changed_position/README.md
+++ b/annotations/fenix/metrics/toolbar_settings.changed_position/README.md
@@ -2,7 +2,3 @@
 tags:
   - Toolbar
 ---
-
-This is a stub commentary for the `toolbar_settings.changed_position` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.long_press/README.md
+++ b/annotations/fenix/metrics/top_sites.long_press/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `top_sites.long_press` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_default/README.md
+++ b/annotations/fenix/metrics/top_sites.open_default/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `top_sites.open_default` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_frecency/README.md
+++ b/annotations/fenix/metrics/top_sites.open_frecency/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `top_sites.open_frecency` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_google_search_attribution/README.md
+++ b/annotations/fenix/metrics/top_sites.open_google_search_attribution/README.md
@@ -2,7 +2,3 @@
 tags:
   - Tabs
 ---
-
-This is a stub commentary for the `top_sites.open_google_search_attribution` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_in_new_tab/README.md
+++ b/annotations/fenix/metrics/top_sites.open_in_new_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `top_sites.open_in_new_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_in_private_tab/README.md
+++ b/annotations/fenix/metrics/top_sites.open_in_private_tab/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `top_sites.open_in_private_tab` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.open_pinned/README.md
+++ b/annotations/fenix/metrics/top_sites.open_pinned/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `top_sites.open_pinned` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.remove/README.md
+++ b/annotations/fenix/metrics/top_sites.remove/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `top_sites.remove` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/top_sites.swipe_carousel/README.md
+++ b/annotations/fenix/metrics/top_sites.swipe_carousel/README.md
@@ -2,7 +2,3 @@
 tags:
   - TopSites
 ---
-
-This is a stub commentary for the `top_sites.swipe_carousel` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.etp_setting_changed/README.md
+++ b/annotations/fenix/metrics/tracking_protection.etp_setting_changed/README.md
@@ -2,7 +2,3 @@
 tags:
   - TrackingProtection
 ---
-
-This is a stub commentary for the `tracking_protection.etp_setting_changed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.etp_settings/README.md
+++ b/annotations/fenix/metrics/tracking_protection.etp_settings/README.md
@@ -2,7 +2,3 @@
 tags:
   - TrackingProtection
 ---
-
-This is a stub commentary for the `tracking_protection.etp_settings` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.etp_shield/README.md
+++ b/annotations/fenix/metrics/tracking_protection.etp_shield/README.md
@@ -2,7 +2,3 @@
 tags:
   - TrackingProtection
 ---
-
-This is a stub commentary for the `tracking_protection.etp_shield` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.etp_tracker_list/README.md
+++ b/annotations/fenix/metrics/tracking_protection.etp_tracker_list/README.md
@@ -2,7 +2,3 @@
 tags:
   - TrackingProtection
 ---
-
-This is a stub commentary for the `tracking_protection.etp_tracker_list` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.exception_added/README.md
+++ b/annotations/fenix/metrics/tracking_protection.exception_added/README.md
@@ -2,7 +2,3 @@
 tags:
   - TrackingProtection
 ---
-
-This is a stub commentary for the `tracking_protection.exception_added` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/tracking_protection.panel_settings/README.md
+++ b/annotations/fenix/metrics/tracking_protection.panel_settings/README.md
@@ -2,7 +2,3 @@
 tags:
   - TrackingProtection
 ---
-
-This is a stub commentary for the `tracking_protection.panel_settings` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/user_specified_search_engines.custom_engine_added/README.md
+++ b/annotations/fenix/metrics/user_specified_search_engines.custom_engine_added/README.md
@@ -2,7 +2,3 @@
 tags:
   - SearchProvider
 ---
-
-This is a stub commentary for the `user_specified_search_engines.custom_engine_added` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/user_specified_search_engines.custom_engine_deleted/README.md
+++ b/annotations/fenix/metrics/user_specified_search_engines.custom_engine_deleted/README.md
@@ -2,7 +2,3 @@
 tags:
   - SearchProvider
 ---
-
-This is a stub commentary for the `user_specified_search_engines.custom_engine_deleted` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/user_specified_search_engines.search_with_custom_engine/README.md
+++ b/annotations/fenix/metrics/user_specified_search_engines.search_with_custom_engine/README.md
@@ -2,7 +2,3 @@
 tags:
   - Logins
 ---
-
-This is a stub commentary for the `user_specified_search_engines.search_with_custom_engine` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/voice_search.tapped/README.md
+++ b/annotations/fenix/metrics/voice_search.tapped/README.md
@@ -3,7 +3,3 @@ tags:
   - Search
   - Voice
 ---
-
-This is a stub commentary for the `voice_search.tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/scripts/create-api.py
+++ b/scripts/create-api.py
@@ -39,7 +39,12 @@ def linkify(text):
 def read_annotation(filename, valid_tags):
     annotation_md = frontmatter.load(filename)
 
-    annotation = {"content": linkify(annotation_md.content)}
+    annotation = {}
+
+    # only specify commentary if we actually have some
+    if annotation_md.content.strip():
+        annotation["commentary"] = linkify(annotation_md.content)
+
     for key in ["component", "tags", "warning"]:
         if annotation_md.get(key):
             annotation[key] = annotation_md[key]


### PR DESCRIPTION
It's better just to leave this blank, we can get the Glean Dictionary
to add some kind of placeholder when we have (for example) tags but no
annotations, which is increasingly common for Fenix.

This also changes the API slightly to change the "content" property
for an annotation to "commentary" (makes consuming this API inside
the Glean Dictionary slightly easier).