### PR TITLE
Fix tag for home screen displayed metric on Fenix

### DIFF
--- a/annotations/fenix/metrics/home_screen.home_screen_displayed/README.md
+++ b/annotations/fenix/metrics/home_screen.home_screen_displayed/README.md
@@ -1,5 +1,4 @@
 ---
 tags:
-  - Settings
-  - MainMenu
+  - HomeScreen
 ---


### PR DESCRIPTION
Complements https://github.com/mozilla-mobile/fenix/pull/21088