### PR TITLE
Add Fenix Credit Card Autofill Telemetry Annotations

### DIFF
--- a/annotations/fenix/metrics/credit_cards.autofill_prompt_dismissed/README.md
+++ b/annotations/fenix/metrics/credit_cards.autofill_prompt_dismissed/README.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - Autofill
+---
+
+This is a stub commentary for the `credit_card.autofill_prompt_dismissed` metric: please feel free to edit (read the
+[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
+if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.autofill_prompt_dismissed/README.md
+++ b/annotations/fenix/metrics/credit_cards.autofill_prompt_dismissed/README.md
@@ -2,7 +2,3 @@
 tags:
   - Autofill
 ---
-
-This is a stub commentary for the `credit_card.autofill_prompt_dismissed` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.autofill_prompt_expanded/README.md
+++ b/annotations/fenix/metrics/credit_cards.autofill_prompt_expanded/README.md
@@ -2,7 +2,3 @@
 tags:
   - Autofill
 ---
-
-This is a stub commentary for the `credit_card.autofill_prompt_expanded` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.autofill_prompt_expanded/README.md
+++ b/annotations/fenix/metrics/credit_cards.autofill_prompt_expanded/README.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - Autofill
+---
+
+This is a stub commentary for the `credit_card.autofill_prompt_expanded` metric: please feel free to edit (read the
+[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
+if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.autofill_prompt_shown/README.md
+++ b/annotations/fenix/metrics/credit_cards.autofill_prompt_shown/README.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - Autofill
+---
+
+This is a stub commentary for the `credit_card.autofill_prompt_shown` metric: please feel free to edit (read the
+[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
+if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.autofill_prompt_shown/README.md
+++ b/annotations/fenix/metrics/credit_cards.autofill_prompt_shown/README.md
@@ -2,7 +2,3 @@
 tags:
   - Autofill
 ---
-
-This is a stub commentary for the `credit_card.autofill_prompt_shown` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.autofilled/README.md
+++ b/annotations/fenix/metrics/credit_cards.autofilled/README.md
@@ -2,7 +2,3 @@
 tags:
   - Autofill
 ---
-
-This is a stub commentary for the `credit_card.autofilled` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.autofilled/README.md
+++ b/annotations/fenix/metrics/credit_cards.autofilled/README.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - Autofill
+---
+
+This is a stub commentary for the `credit_card.autofilled` metric: please feel free to edit (read the
+[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
+if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.deleted/README.md
+++ b/annotations/fenix/metrics/credit_cards.deleted/README.md
@@ -2,7 +2,3 @@
 tags:
   - Autofill
 ---
-
-This is a stub commentary for the `credit_card.deleted` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.deleted/README.md
+++ b/annotations/fenix/metrics/credit_cards.deleted/README.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - Autofill
+---
+
+This is a stub commentary for the `credit_card.deleted` metric: please feel free to edit (read the
+[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
+if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.form_detected/README.md
+++ b/annotations/fenix/metrics/credit_cards.form_detected/README.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - Autofill
+---
+
+This is a stub commentary for the `credit_card.form_detected` metric: please feel free to edit (read the
+[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
+if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.form_detected/README.md
+++ b/annotations/fenix/metrics/credit_cards.form_detected/README.md
@@ -2,7 +2,3 @@
 tags:
   - Autofill
 ---
-
-This is a stub commentary for the `credit_card.form_detected` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.management_add_tapped/README.md
+++ b/annotations/fenix/metrics/credit_cards.management_add_tapped/README.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - Autofill
+---
+
+This is a stub commentary for the `credit_card.management_add_tapped` metric: please feel free to edit (read the
+[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
+if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.management_add_tapped/README.md
+++ b/annotations/fenix/metrics/credit_cards.management_add_tapped/README.md
@@ -2,7 +2,3 @@
 tags:
   - Autofill
 ---
-
-This is a stub commentary for the `credit_card.management_add_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.management_card_tapped/README.md
+++ b/annotations/fenix/metrics/credit_cards.management_card_tapped/README.md
@@ -2,7 +2,3 @@
 tags:
   - Autofill
 ---
-
-This is a stub commentary for the `credit_card.management_card_tapped` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.management_card_tapped/README.md
+++ b/annotations/fenix/metrics/credit_cards.management_card_tapped/README.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - Autofill
+---
+
+This is a stub commentary for the `credit_card.management_card_tapped` metric: please feel free to edit (read the
+[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
+if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.modified/README.md
+++ b/annotations/fenix/metrics/credit_cards.modified/README.md
@@ -2,7 +2,3 @@
 tags:
   - Autofill
 ---
-
-This is a stub commentary for the `credit_card.modified` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.modified/README.md
+++ b/annotations/fenix/metrics/credit_cards.modified/README.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - Autofill
+---
+
+This is a stub commentary for the `credit_card.modified` metric: please feel free to edit (read the
+[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
+if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.saved/README.md
+++ b/annotations/fenix/metrics/credit_cards.saved/README.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - Autofill
+---
+
+This is a stub commentary for the `credit_card.saved` metric: please feel free to edit (read the
+[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
+if you haven't done this before)

--- a/annotations/fenix/metrics/credit_cards.saved/README.md
+++ b/annotations/fenix/metrics/credit_cards.saved/README.md
@@ -2,7 +2,3 @@
 tags:
   - Autofill
 ---
-
-This is a stub commentary for the `credit_card.saved` metric: please feel free to edit (read the
-[contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
-if you haven't done this before)


### PR DESCRIPTION
This is to add Fenix credit card autofill telemetry annotations.