### PR TITLE
Add richer app metadata

### DIFF
--- a/annotations/fenix/README.md
+++ b/annotations/fenix/README.md
@@ -1,5 +1,5 @@
 ---
-featured: true
+featured: true # display first on front page of glean dictionary
 logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/logo.svg
 tags:
   - Android

--- a/annotations/fenix/README.md
+++ b/annotations/fenix/README.md
@@ -1,0 +1,6 @@
+---
+featured: true
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/logo.svg
+tags:
+  - Android
+---

--- a/annotations/firefox_desktop/README.md
+++ b/annotations/firefox_desktop/README.md
@@ -1,5 +1,5 @@
 ---
-featured: true
+featured: true # display first on front page of glean dictionary
 logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/logo.svg
 warning: >
   Most Firefox Desktop telemetry is still being collected via the legacy Firefox Telemetry

--- a/annotations/firefox_desktop/README.md
+++ b/annotations/firefox_desktop/README.md
@@ -1,4 +1,6 @@
 ---
+featured: true
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/logo.svg
 warning: >
   Most Firefox Desktop telemetry is still being collected via the legacy Firefox Telemetry
   collection system. A full list of this telemetry is available in the [probe dictionary](https://probes.telemetry.mozilla.org).

--- a/annotations/firefox_desktop_background_update/README.md
+++ b/annotations/firefox_desktop_background_update/README.md
@@ -1,3 +1,6 @@
+---
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/logo.svg
+---
 As of this writing, the [Firefox Background Updater](https://firefox-source-docs.mozilla.org/toolkit/mozapps/update/docs/BackgroundUpdates.html) is Windows-only.
 The data it sends is operational and is not designed to answer questions about user behaviour.
 

--- a/annotations/firefox_echo_show/README.md
+++ b/annotations/firefox_echo_show/README.md
@@ -1,0 +1,5 @@
+---
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/logo.svg
+tags:
+  - Amazon
+---

--- a/annotations/firefox_fire_tv/README.md
+++ b/annotations/firefox_fire_tv/README.md
@@ -1,0 +1,5 @@
+---
+logo: https://github.com/mozilla/glean-dictionary/raw/05a8267337b175f1200fc0c6f5e52e87bed05138/public/img/app-logos/amazon.png
+tags:
+  - Amazon
+---

--- a/annotations/firefox_ios/README.md
+++ b/annotations/firefox_ios/README.md
@@ -1,0 +1,6 @@
+---
+featured: true
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/logo.svg
+tags:
+  - iOS
+---

--- a/annotations/firefox_ios/README.md
+++ b/annotations/firefox_ios/README.md
@@ -1,5 +1,5 @@
 ---
-featured: true
+featured: true # display first on front page of glean dictionary
 logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/logo.svg
 tags:
   - iOS

--- a/annotations/firefox_reality/README.md
+++ b/annotations/firefox_reality/README.md
@@ -1,0 +1,3 @@
+---
+logo: https://raw.githubusercontent.com/mozilla/glean-dictionary/main/public/img/app-logos/reality.png
+---

--- a/annotations/firefox_reality_pc/README.md
+++ b/annotations/firefox_reality_pc/README.md
@@ -1,0 +1,3 @@
+---
+logo: https://raw.githubusercontent.com/mozilla/glean-dictionary/main/public/img/app-logos/reality.png
+---

--- a/annotations/focus_android/README.md
+++ b/annotations/focus_android/README.md
@@ -1,5 +1,5 @@
 ---
-featured: true
+featured: true # display first on front page of glean dictionary
 logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/focus/logo.svg
 tags:
   - Android

--- a/annotations/focus_android/README.md
+++ b/annotations/focus_android/README.md
@@ -1,0 +1,6 @@
+---
+featured: true
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/focus/logo.svg
+tags:
+  - Android
+---

--- a/annotations/focus_ios/README.md
+++ b/annotations/focus_ios/README.md
@@ -1,0 +1,6 @@
+---
+featured: true
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/focus/logo.svg
+tags:
+  - iOS
+---

--- a/annotations/focus_ios/README.md
+++ b/annotations/focus_ios/README.md
@@ -1,5 +1,5 @@
 ---
-featured: true
+featured: true # display first on front page of glean dictionary
 logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/focus/logo.svg
 tags:
   - iOS

--- a/annotations/glean_dictionary/README.md
+++ b/annotations/glean_dictionary/README.md
@@ -1,0 +1,3 @@
+---
+logo: https://raw.githubusercontent.com/mozilla/glean-dictionary/05a8267337b175f1200fc0c6f5e52e87bed05138/public/favicon.png
+---

--- a/annotations/klar_android/README.md
+++ b/annotations/klar_android/README.md
@@ -1,5 +1,5 @@
 ---
-featured: true
+featured: true # display first on front page of glean dictionary
 logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/focus/logo.svg
 tags:
   - Android

--- a/annotations/klar_android/README.md
+++ b/annotations/klar_android/README.md
@@ -1,0 +1,6 @@
+---
+featured: true
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/focus/logo.svg
+tags:
+  - Android
+---

--- a/annotations/klar_ios/README.md
+++ b/annotations/klar_ios/README.md
@@ -1,0 +1,6 @@
+---
+featured: true
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/focus/logo.svg
+tags:
+  - iOS
+---

--- a/annotations/klar_ios/README.md
+++ b/annotations/klar_ios/README.md
@@ -1,5 +1,5 @@
 ---
-featured: true
+featured: true # display first on front page of glean dictionary
 logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/browser/focus/logo.svg
 tags:
   - iOS

--- a/annotations/lockwise_android/README.md
+++ b/annotations/lockwise_android/README.md
@@ -1,0 +1,5 @@
+---
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/lockwise/logo.svg
+tags:
+  - Android
+---

--- a/annotations/lockwise_ios/README.md
+++ b/annotations/lockwise_ios/README.md
@@ -1,0 +1,5 @@
+---
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/main/logos/firefox/lockwise/logo.svg
+tags:
+  - iOS
+---

--- a/annotations/mozilla_vpn/README.md
+++ b/annotations/mozilla_vpn/README.md
@@ -1,0 +1,4 @@
+---
+featured: true
+logo: https://raw.githubusercontent.com/mozilla/protocol-assets/60775b3dda4dacb036f9f0cd4f48bf9563ffbc15/logos/mozilla/vpn/logo.svg
+---

--- a/annotations/mozilla_vpn/README.md
+++ b/annotations/mozilla_vpn/README.md
@@ -1,4 +1,4 @@
 ---
-featured: true
+featured: true # display first on front page of glean dictionary
 logo: https://raw.githubusercontent.com/mozilla/protocol-assets/60775b3dda4dacb036f9f0cd4f48bf9563ffbc15/logos/mozilla/vpn/logo.svg
 ---

--- a/annotations/mozregression/README.md
+++ b/annotations/mozregression/README.md
@@ -1,0 +1,3 @@
+---
+logo: https://github.com/mozilla/mozregression/raw/ad85ca7646bf44b2f2312a5cc45d25616f727d73/docs/images/mozregression_logo_128.png
+---

--- a/annotations/mozregression/README.md
+++ b/annotations/mozregression/README.md
@@ -1,3 +1,3 @@
 ---
-logo: https://github.com/mozilla/mozregression/raw/ad85ca7646bf44b2f2312a5cc45d25616f727d73/docs/images/mozregression_logo_128.png
+logo: https://raw.githubusercontent.com/mozilla/mozregression/3b4952893b82dd1901181be93f855907fbb12598/docs/images/mozregression_logo_256.png
 ---

--- a/annotations/reference_browser/README.md
+++ b/annotations/reference_browser/README.md
@@ -1,0 +1,5 @@
+---
+logo: https://github.com/mozilla-mobile/reference-browser/raw/master/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png
+tags:
+  - Android
+---


### PR DESCRIPTION
Instead of hardcoding an application's logo and "featured" status
in the Glean Dictionary, allow specifying it here so that the Glean
Dictionary can consume this information.
