### PR TITLE
Create README.md for locale in Firefox Desktop

### DIFF
--- a/annotations/glean-core/metrics/locale/README.md
+++ b/annotations/glean-core/metrics/locale/README.md
@@ -1,1 +1,1 @@
-Application Locale has been added to Glean (in the [`client_info.locale' metric](https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/locale)) as of Firefox v118. See [Bug 1626969](https://bugzilla.mozilla.org/show_bug.cgi?id=1626969) for more information. 
+Application Locale has been added to Glean (in the [`client_info.locale` metric](https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/locale)) as of Firefox v118. See [Bug 1626969](https://bugzilla.mozilla.org/show_bug.cgi?id=1626969) for more information. 

--- a/annotations/glean-core/metrics/locale/README.md
+++ b/annotations/glean-core/metrics/locale/README.md
@@ -1,0 +1,1 @@
+Application Locale has been added to Glean (in the [`client_info.locale' metric](https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/locale)) as of Firefox v118. See [Bug 1626969](https://bugzilla.mozilla.org/show_bug.cgi?id=1626969) for more information. 


### PR DESCRIPTION
Adding the first Gleannotation for `client_info.locale` in Firefox Desktop