### PR TITLE
add annotations for metrics removed from usage ping

### DIFF
--- a/annotations/glean-android/metrics/android_sdk_version/README.md
+++ b/annotations/glean-android/metrics/android_sdk_version/README.md
@@ -1,0 +1,1 @@
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).

--- a/annotations/glean-core/metrics/architecture/README.md
+++ b/annotations/glean-core/metrics/architecture/README.md
@@ -1,0 +1,1 @@
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).

--- a/annotations/glean-core/metrics/build_date/README.md
+++ b/annotations/glean-core/metrics/build_date/README.md
@@ -1,0 +1,1 @@
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).

--- a/annotations/glean-core/metrics/client_id/README.md
+++ b/annotations/glean-core/metrics/client_id/README.md
@@ -1,0 +1,1 @@
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).

--- a/annotations/glean-core/metrics/device_manufacturer/README.md
+++ b/annotations/glean-core/metrics/device_manufacturer/README.md
@@ -1,0 +1,1 @@
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).

--- a/annotations/glean-core/metrics/device_model/README.md
+++ b/annotations/glean-core/metrics/device_model/README.md
@@ -1,0 +1,1 @@
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).

--- a/annotations/glean-core/metrics/end_time/README.md
+++ b/annotations/glean-core/metrics/end_time/README.md
@@ -1,2 +1,4 @@
 This ends up being a string in the data and is not easily parsed into a `DATE` or `TIMESTAMP`, thus there is a 
 pre-parsed version that is much easier to use `ping_info.parsed_end_time` when writing queries.
+
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).

--- a/annotations/glean-core/metrics/experiments/README.md
+++ b/annotations/glean-core/metrics/experiments/README.md
@@ -1,0 +1,1 @@
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).

--- a/annotations/glean-core/metrics/locale/README.md
+++ b/annotations/glean-core/metrics/locale/README.md
@@ -1,1 +1,3 @@
 Application Locale has been added to Glean (in the [`client_info.locale` metric](https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/locale)) as of Firefox v118. See [Bug 1626969](https://bugzilla.mozilla.org/show_bug.cgi?id=1626969) for more information. 
+
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).

--- a/annotations/glean-core/metrics/seq/README.md
+++ b/annotations/glean-core/metrics/seq/README.md
@@ -1,0 +1,1 @@
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).

--- a/annotations/glean-core/metrics/start_time/README.md
+++ b/annotations/glean-core/metrics/start_time/README.md
@@ -1,2 +1,4 @@
 This ends up being a string in the data and is not easily parsed into a `DATE` or `TIMESTAMP`, thus there is a 
 pre-parsed version that is much easier to use `ping_info.parsed_start_time` when writing queries.
+
+This metric is no longer sent in the usage reporting ping. See [Bug 1929832](https://bugzilla.mozilla.org/show_bug.cgi?id=1929832).


### PR DESCRIPTION
These are annotations to make clear that these metrics no longer exist in the usage ping. 

Once we have a solution for [this issue](https://github.com/mozilla/glean-dictionary/issues/2282#issuecomment-2597137733) these comments will be redundant. 