### PR TITLE
FXIOS-12626 [iOS Telemetry Audit] Add annotation for iOS `share_sheet.shared_to` event

### DIFF
--- a/annotations/firefox_ios/metrics/share_sheet.shared_to/README.md
+++ b/annotations/firefox_ios/metrics/share_sheet.shared_to/README.md
@@ -1,0 +1,35 @@
+Please see the following query for the top share types in the past 120 days: https://sql.telemetry.mozilla.org/queries/105360
+
+Firefox activity identifiers:
+
+| Activity Identifier                  | App                          |
+| ------------------------------------ | ---------------------------- |
+| org.mozilla.ios.Fennec.sendToDevice  | Firefox Send to Device       |
+| org.mozilla.ios.Firefox.ShareTo      | Firefox Share To Extension   |
+| org.mozilla.ios.Focus.ShareExtension | Firefox Focus App            |
+| org.mozilla.ios.Klar.ShareExtension  | Firefox Klar                 |
+| org.mozilla.ios.XRViewer.ShareTo     | Firefox Project WebXR Viewer |
+| org.mozilla.ios.FirefoxBeta.ShareTo  | Firefox Beta                 |
+
+Other common identifiers include:
+
+| Activity Identifier                                      | App                                 |
+| -------------------------------------------------------- | ----------------------------------- |
+| com.apple.UIKit.activity.Message                         | Messages                            |
+| com.apple.DocumentManagerUICore.SaveToFiles              | Save to Files                       |
+| com.apple.UIKit.activity.Print                           | Print                               |
+| com.apple.UIKit.activity.Mail                            | Mail                                |
+| com.apple.UIKit.activity.CopyToPasteboard                | Copy to Pasteboard                  |
+| com.apple.UIKit.activity.AirDrop                         | AirDrop                             |
+| com.apple.UIKit.activity.AddToHomeScreen                 | Add to Home Screen                  |
+| com.apple.UIKit.activity.RemoteOpenInApplication-ByCopy  | An app that handles a file via copy |
+| com.apple.UIKit.activity.RemoteOpenInApplication-InPlace | An app that handles a file in place |
+| com.apple.mobilenotes.SharingExtension                   | Notes                               |
+| com.apple.UIKit.activity.SaveToCameraRoll                | Camera Roll                         |
+| com.apple.UIKit.activity.MarkupAsPDF                     | Markup as PDF                       |
+| net.whatsapp.WhatsApp.ShareExtension                     | WhatsApp                            |
+| com.google.Gmail.ShareExtension                          | Gmail                               |
+| com.facebook.Messenger.ShareExtension                    | Facebook Messenger                  |
+| org.whispersystems.signal.shareextension                 | Signal Messaging                    |
+| ph.telegra.Telegraph.Share                               | Telegram Messaging                  |
+| com.google.Drive.ShareExtension                          | Google Drive                        |


### PR DESCRIPTION
Related ticket: [FXIOS-12626](https://mozilla-hub.atlassian.net/browse/FXIOS-12626)

I thought I'd test out adding a new Glean annotation for the iOS repo, as this capability hasn't been leveraged by the iOS team for years now!

The docs say that sql.telemetry.mozilla links automatically get the lock icon, so I didn't add one to the provided query URL. 🙂 